### PR TITLE
More complete .flyntignore file support

### DIFF
--- a/floyd/client/data.py
+++ b/floyd/client/data.py
@@ -19,7 +19,7 @@ class DataClient(FloydHttpClient):
         try:
             upload_files, total_file_size = get_files_in_directory(path='.', file_type='data')
         except OSError:
-            sys.exit("Directory contains too many files to upload. Add unused directories to .floydignore file. "
+            sys.exit("Directory contains too many files to upload. Add unused files and directories to .floydignore file. "
                      "Or download data directly from the internet into FloydHub")
 
         request_data = {"json": json.dumps(data.to_dict())}

--- a/floyd/client/files.py
+++ b/floyd/client/files.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import PurePath
 
 from floyd.manager.floyd_ignore import FloydIgnoreManager
 from floyd.log import logger as floyd_logger
@@ -12,14 +13,14 @@ def get_files_in_directory(path, file_type):
     local_files = []
     separator = os.path.sep
     ignore_list = FloydIgnoreManager.get_list()
-    ignore_list_localized = [".{}{}".format(separator, item) for item in ignore_list]
-    floyd_logger.debug("Ignoring list : {}".format(ignore_list_localized))
+    floyd_logger.debug("Ignoring list : {}".format(ignore_list))
     total_file_size = 0
 
     for root, dirs, files in os.walk(path):
         ignore_dir = False
-        for item in ignore_list_localized:
-            if root.startswith(item):
+        normalized_path = normalize_path(path, root)
+        for item in ignore_list:
+            if PurePath(normalized_path).match(item):
                 ignore_dir = True
 
         if ignore_dir:
@@ -27,6 +28,16 @@ def get_files_in_directory(path, file_type):
             continue
 
         for file_name in files:
+            ignore_file = False
+            normalized_path = normalize_path(path, os.path.join(root, file_name))
+            for item in ignore_list:
+                if PurePath(normalized_path).match(item):
+                    ignore_file = True
+
+            if ignore_file:
+                floyd_logger.debug("Ignoring file : {}".format(normalized_path))
+                continue
+
             file_relative_path = os.path.join(root, file_name)
             if separator != '/':  # convert relative paths to Unix style
                 file_relative_path = file_relative_path.replace(os.path.sep, '/')
@@ -36,6 +47,22 @@ def get_files_in_directory(path, file_type):
             total_file_size += os.path.getsize(file_full_path)
 
     return (local_files, sizeof_fmt(total_file_size))
+
+
+def normalize_path(project_root, path):
+    """
+    Convert `path` to a UNIX style path, where `project_root` becomes the root
+    of an imaginery file system (i.e. becomes just an initial "/").
+    """
+    if os.path.sep != '/':
+        path = path.replace(os.path.sep, '/')
+        project_root = project_root.replace(os.path.sep, '/')
+
+    path = path[len(project_root):] if path.startswith(project_root) else path
+    path = '/' + path if not path.startswith('/') else path
+
+    return path
+
 
 
 def sizeof_fmt(num, suffix='B'):

--- a/floyd/client/module.py
+++ b/floyd/client/module.py
@@ -18,7 +18,7 @@ class ModuleClient(FloydHttpClient):
         try:
             upload_files, total_file_size = get_files_in_directory(path='.', file_type='code')
         except OSError:
-            sys.exit("Directory contains too many files to upload. Add unused directories to .floydignore file."
+            sys.exit("Directory contains too many files to upload. Add unused files and directories to .floydignore file."
                      "Or download data directly from the internet into FloydHub")
 
         request_data = {"json": json.dumps(module.to_dict())}

--- a/floyd/client/usage.py
+++ b/floyd/client/usage.py
@@ -19,7 +19,7 @@ class DataClient(FloydHttpClient):
         try:
             upload_files, total_file_size = get_files_in_directory(path='.', file_type='data')
         except OSError:
-            sys.exit("Directory contains too many files to upload. Add unused directories to .floydignore file. "
+            sys.exit("Directory contains too many files to upload. Add unused files and directories to .floydignore file. "
                      "Or download data directly from the internet into FloydHub")
 
         request_data = {"json": json.dumps(data.to_dict())}


### PR DESCRIPTION
A support for some new features in`.flyntignore`, known from `.gitignore` files. I know you guys are working on something much bigger, but maybe this can serve as a temporary solution (as I get quite a lot of questions about this on Slack).

Some examples:
```

# Ignore all .dat files in the whole project:
*.dat

# Ignore all .dat files in some_folder:
/some_folder/*.dat

# Ignore all .dat files in some_folder and its subfolders:
/some_folder/**/*.dat

# Ignore all files (and folders) named .DS_Store
.DS_Store

# Ignore a specific file named .DS_Store located in some_folder
/some_folder/.DS_Store

# Ignore all files named .DS_Store in some_folder and its subfolders
/some_folder/**/.DS_Store

# Ignore all files in some_folder
/some_folder

# Ignore all files in some_folder (works the same as the rule above)
/some_folder/
```