### PR TITLE
fix(crash): decode server response with proper encoding

### DIFF
--- a/floyd/client/common.py
+++ b/floyd/client/common.py
@@ -9,6 +9,6 @@ def get_url_contents(url):
     """
     response = requests.get(url)
     if response.status_code == 200:
-        return response.content.decode()
+        return response.content.decode(response.encoding)
     else:
         raise FloydException("Failed to get contents of the url : {}".format(url))

--- a/tests/client/common_test.py
+++ b/tests/client/common_test.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import mock
+
+
+def mocked_requests_utf8_get(*args, **kwargs):
+    class MockResponse:
+        encoding = 'utf-8'
+        status_code = 200
+        content = b'\xe2\x80\x98sample.tgz\xe2\x80\x99'
+
+    return MockResponse()
+
+
+class TestCommonHelperFunctions(unittest.TestCase):
+    """
+    Tests helper functions in floyd.client.common
+    """
+    @mock.patch('requests.get', side_effect=mocked_requests_utf8_get)
+    def test_get_url_contents(self, mocked_get):
+        from floyd.client.common import get_url_contents
+        self.assertEqual(get_url_contents('foobar.baz/api/v1/content'),
+                         u'\u2018sample.tgz\u2019')


### PR DESCRIPTION
Prior to this fix, client will crash with the following error under py2:

```
 line 13, in get_url_contents
    return response.content.decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1170: ordinal not in range(128)
```

You can try reproduce it with `floyd logs -t LbiFKtkCV7tZo4aaDtfYga `
