### PR TITLE
Allow delete command to accept multiple experiment ids

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     ],
     setup_requires=[
         "nose>=1.0",
-        "mock>=1.0.1",
     ],
     dependency_links=[
     ],

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     ],
     setup_requires=[
         "nose>=1.0",
+        "mock>=1.0.1",
     ],
     dependency_links=[
     ],
@@ -39,6 +40,7 @@ setup(
         ],
     },
     tests_require=[
+        "nose>=1.0",
         "mock>=1.0.1",
     ],
 )

--- a/tests/cli/experiment/delete_test.py
+++ b/tests/cli/experiment/delete_test.py
@@ -4,7 +4,8 @@ from mock import patch, call
 
 import floyd
 from floyd.cli.experiment import delete
-from .mocks import mock_exp, mock_running_exp, mock_queued_exp, mock_task_inst
+from tests.cli.experiment.mocks import mock_exp, mock_running_exp, \
+                                       mock_queued_exp, mock_task_inst
 
 
 class TestExperiementDelete(unittest.TestCase):

--- a/tests/cli/experiment/delete_test.py
+++ b/tests/cli/experiment/delete_test.py
@@ -2,13 +2,12 @@ from click.testing import CliRunner
 import unittest
 from mock import patch, call
 
-import floyd
 from floyd.cli.experiment import delete
 from tests.cli.experiment.mocks import mock_exp, mock_running_exp, \
                                        mock_queued_exp, mock_task_inst
 
 
-class TestExperiementDelete(unittest.TestCase):
+class TestExperimentDelete(unittest.TestCase):
     """
     Tests Experiment CLI delete functionality `floyd delete`
     """

--- a/tests/cli/experiment/delete_test.py
+++ b/tests/cli/experiment/delete_test.py
@@ -1,0 +1,128 @@
+from click.testing import CliRunner
+import unittest
+from mock import patch, call
+
+import floyd
+from floyd.cli.experiment import delete
+from .mocks import mock_exp, mock_running_exp, mock_queued_exp, mock_task_inst
+
+
+class TestExperiementDelete(unittest.TestCase):
+    """
+    Tests Experiment CLI delete functionality `floyd delete`
+    """
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch('floyd.cli.experiment.TaskInstanceClient')
+    @patch('floyd.cli.experiment.ModuleClient')
+    @patch('floyd.cli.experiment.ExperimentClient')
+    def test_with_no_arguments(self, *api_clients):
+        result = self.runner.invoke(delete)
+
+        # No calls to API clients, exit 0
+        for client in api_clients:
+            client.assert_not_called()
+
+        assert(result.exit_code == 0)
+
+    @patch('floyd.cli.experiment.TaskInstanceClient.get',
+           side_effect=mock_task_inst)
+    @patch('floyd.cli.experiment.ModuleClient.delete')
+    @patch('floyd.cli.experiment.ExperimentClient.get', side_effect=mock_exp)
+    @patch('floyd.cli.experiment.ExperimentClient.delete')
+    def test_with_multiple_ids_and_yes_option(self,
+                                              delete_experiment,
+                                              get_experiment,
+                                              delete_module,
+                                              get_task_instance):
+        id_1, id_2, id_3 = '1', '2', '3'
+        result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
+
+        # Trigger a get and a delete for each id
+        calls = [call(id_1), call(id_2), call(id_3)]
+        get_experiment.assert_has_calls(calls, any_order=True)
+        get_task_instance.assert_called()
+        delete_module.assert_called()
+        delete_experiment.assert_has_calls(calls, any_order=True)
+
+        assert(result.exit_code == 0)
+
+    @patch('floyd.cli.experiment.TaskInstanceClient.get',
+           side_effect=mock_task_inst)
+    @patch('floyd.cli.experiment.ModuleClient')
+    @patch('floyd.cli.experiment.ExperimentClient.get', side_effect=mock_exp)
+    @patch('floyd.cli.experiment.ExperimentClient.delete')
+    def test_delete_without_yes_option(self,
+                                       delete_experiment,
+                                       get_experiment,
+                                       delete_module, get_task_instance):
+        id_1, id_2, id_3 = '1', '2', '3'
+
+        # Tell prompt to skip id_1 and id_3
+        result = self.runner.invoke(delete,
+                                    [id_1, id_2, id_3],
+                                    input='n\nY\nn\n')
+
+        # Triggers a get for all ids
+        calls = [call(id_1), call(id_2), call(id_3)]
+        get_experiment.assert_has_calls(calls, any_order=True)
+        get_task_instance.assert_called()
+
+        # Calls delete for only id_2
+        delete_experiment.assert_called_once_with(id_2)
+        delete_module.assert_called_once()
+
+        assert(result.exit_code == 0)
+
+    @patch('floyd.cli.experiment.TaskInstanceClient.get',
+           side_effect=mock_task_inst)
+    @patch('floyd.cli.experiment.ModuleClient')
+    @patch('floyd.cli.experiment.ExperimentClient.get',
+           side_effect=mock_queued_exp)
+    @patch('floyd.cli.experiment.ExperimentClient.delete')
+    def test_delete_with_queued_experiments(self,
+                                            delete_experiment,
+                                            get_experiment,
+                                            delete_module,
+                                            get_task_instance):
+        id_1, id_2 = '1', '2'
+
+        result = self.runner.invoke(delete, ['-y', id_1, id_2])
+
+        # Triggers a get for all ids
+        calls = [call(id_1), call(id_2)]
+        get_experiment.assert_has_calls(calls, any_order=True)
+        get_task_instance.assert_called()
+
+        # Does not attempt to delete
+        delete_module.assert_not_called()
+        delete_experiment.assert_not_called()
+
+        assert(result.exit_code == 0)
+
+    @patch('floyd.cli.experiment.TaskInstanceClient.get',
+           side_effect=mock_task_inst)
+    @patch('floyd.cli.experiment.ModuleClient')
+    @patch('floyd.cli.experiment.ExperimentClient.get',
+           side_effect=mock_running_exp)
+    @patch('floyd.cli.experiment.ExperimentClient.delete')
+    def test_delete_with_running_experiments(self,
+                                             delete_experiment,
+                                             get_experiment,
+                                             delete_module,
+                                             get_task_instance):
+        id_1, id_2 = '1', '2'
+
+        result = self.runner.invoke(delete, ['-y', id_1, id_2])
+
+        # Triggers a get for all ids
+        calls = [call(id_1), call(id_2)]
+        get_experiment.assert_has_calls(calls, any_order=True)
+        get_task_instance.assert_called()
+
+        # Does not attempt to delete
+        delete_module.assert_not_called()
+        delete_experiment.assert_not_called()
+
+        assert(result.exit_code == 0)

--- a/tests/cli/experiment/mocks.py
+++ b/tests/cli/experiment/mocks.py
@@ -1,0 +1,31 @@
+def mock_exp(exp_id):
+    class Experiment:
+        id = exp_id
+        state = 'success'
+        name = 'test_name'
+        task_instances = []
+    return Experiment()
+
+
+def mock_running_exp(exp_id):
+    class Experiment:
+        id = exp_id
+        state = 'running'
+        name = 'running experiment'
+        task_instances = []
+    return Experiment()
+
+
+def mock_queued_exp(exp_id):
+    class Experiment:
+        id = exp_id
+        state = 'queued'
+        name = 'queued experiment'
+        task_instances = []
+    return Experiment()
+
+
+def mock_task_inst(exp_id):
+    class TaskInstance:
+        module_id = 'module id'
+    return TaskInstance()


### PR DESCRIPTION
I found myself wanting this feature, and then I noticed that it was requested a couple of times on the forum, too. Here are links to the posts:
[Deleting multiple experiments](https://forum.floydhub.com/t/deleting-multiple-experiments/)
[Delete experiments by name / Bulk delete experiments](https://forum.floydhub.com/t/delete-experiments-by-name-bulk-delete-experiments/95)

I noticed that a similar PR (#7)  was opened to enable this feature for deleting multiple data ids at the same time, but it was closed without any discussion. Is this a feature that you specifically do not want implemented? If so, some insight would be appreciated.

## Some notes on these changes
### Exit 0 even if no ids are passed
As suggested in the [Click documentation](http://click.pocoo.org/6/arguments/#variadic-arguments), I thought it would be best to allow no ids to be passed and still exit successfully, as this command will likely be used by scripts that might not know if they are calling the command with empty arguments.

### Inefficiency of the approach
This implementation deletes the experiments one at a time, which means it makes multiple calls to the API for each id; that's not very efficient.

The API doesn't seem to offer a way to fetch multiple experiments by id at the same time, or delete multiple experiments by id at the same time. Plus, before this implementation, a user would still hit the API as many times, since they would just call `floyd delete <id>` multiple times to get the job done (in fact, we save extra requests to `/api/v1/cli_version`). So, given the current architecture/endpoints of the API, I think this approach is the best we can do. The fact that the requests will be closer together shouldn't make a material impact to server load.

### Tests?
The cli isn't well tested, and I haven't included any tests here, either. If we want to start the trend now, I'd be happy to add some tests. We should probably discuss the approach, though.