### PR TITLE
Allow 'floyd data delete' to accept multiple ids

### DIFF
--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -124,12 +124,17 @@ def delete(ids, yes):
     failures = False
 
     for id in ids:
+        data_source = DataClient().get(id)
+        if not data_source:
+            failures = True
+            continue
+
         if not yes and not click.confirm(
-                                   "Delete Data: {}?".format(id),
+                                   "Delete Data: {}?".format(data_source.name),
                                    abort=False,
                                    default=False
                                  ):
-            floyd_logger.info("Data {}: Skipped".format(id))
+            floyd_logger.info("Data {}: Skipped".format(data_source.name))
             continue
 
         if not DataClient().delete(id):

--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -129,11 +129,9 @@ def delete(ids, yes):
             failures = True
             continue
 
-        if not yes and not click.confirm(
-                                   "Delete Data: {}?".format(data_source.name),
-                                   abort=False,
-                                   default=False
-                                 ):
+        if not yes and not click.confirm("Delete Data: {}?".format(data_source.name),
+                                         abort=False,
+                                         default=False):
             floyd_logger.info("Data {}: Skipped".format(data_source.name))
             continue
 

--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -125,6 +125,9 @@ def delete(ids, yes):
 
     for id in ids:
         data_source = DataClient().get(id)
+        if not data_source:
+            failures = True
+            continue
 
         if not yes and not click.confirm(
                                    "Delete Data: {}?".format(data_source.name),
@@ -134,12 +137,7 @@ def delete(ids, yes):
             floyd_logger.info("Data {}: Skipped".format(data_source.name))
             continue
 
-        if DataClient().delete(id):
-            floyd_logger.info("Data {}: Deleted".format(data_source.name))
-        else:
-            floyd_logger.error(
-                    "Data {}: Failed to delete!".format(data_source.name)
-            )
+        if not DataClient().delete(id):
             failures = True
 
     if failures:

--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -124,17 +124,12 @@ def delete(ids, yes):
     failures = False
 
     for id in ids:
-        data_source = DataClient().get(id)
-        if not data_source:
-            failures = True
-            continue
-
         if not yes and not click.confirm(
-                                   "Delete Data: {}?".format(data_source.name),
+                                   "Delete Data: {}?".format(id),
                                    abort=False,
                                    default=False
                                  ):
-            floyd_logger.info("Data {}: Skipped".format(data_source.name))
+            floyd_logger.info("Data {}: Skipped".format(id))
             continue
 
         if not DataClient().delete(id):

--- a/floyd/client/base.py
+++ b/floyd/client/base.py
@@ -3,13 +3,11 @@ import sys
 
 import floyd
 from floyd.manager.auth_config import AuthConfigManager
-from floyd.exceptions import AuthenticationException, BadRequestException, NotFoundException, OverLimitException
-
-from floyd.exceptions import AuthenticationException, AuthorizationException, \
-                             BadGatewayException, BadRequestException,        \
-                             FloydException, GatewayTimeoutException,         \
-                             NotFoundException, OverLimitException,           \
-                             ServerException
+from floyd.exceptions import (AuthenticationException, AuthorizationException,
+                              BadGatewayException, BadRequestException,
+                              FloydException, GatewayTimeoutException,
+                              NotFoundException, OverLimitException,
+                              ServerException)
 
 from floyd.log import logger as floyd_logger
 

--- a/floyd/client/data.py
+++ b/floyd/client/data.py
@@ -84,7 +84,7 @@ class DataClient(FloydHttpClient):
             return None
         except HTTPError as e:
             floyd_logger.info(
-                    "Data {}: Error fetching from server.".format(id)
+                    "Data {}: Error fetching id from server.".format(id)
             )
             return None
 

--- a/floyd/client/data.py
+++ b/floyd/client/data.py
@@ -90,9 +90,7 @@ class DataClient(FloydHttpClient):
             experiments_dict = response.json()
             return [Data.from_dict(expt) for expt in experiments_dict]
         except FloydException as e:
-            floyd_logger.info(
-               "Error while retrieving data: {}".format(e.message)
-            )
+            floyd_logger.info("Error while retrieving data: {}".format(e.message))
             return None
 
     def delete(self, id):

--- a/floyd/client/data.py
+++ b/floyd/client/data.py
@@ -84,7 +84,7 @@ class DataClient(FloydHttpClient):
             return None
         except HTTPError as e:
             floyd_logger.info(
-                    "Data {}: Error fetching id from server.".format(id)
+                    "Data {}: Error fetching from server.".format(id)
             )
             return None
 

--- a/floyd/exceptions.py
+++ b/floyd/exceptions.py
@@ -7,25 +7,49 @@ class FloydException(ClickException):
         super(FloydException, self).__init__(message)
 
 
-class AuthenticationException(ClickException):
+class AuthenticationException(FloydException):
 
     def __init__(self, message="Authentication failed. Retry by invoking floyd login."):
         super(AuthenticationException, self).__init__(message=message)
 
 
-class NotFoundException(ClickException):
+class AuthorizationException(FloydException):
 
-    def __init__(self, message="The resource you are looking for is not found. Check if the id is correct."):
+    def __init__(self, message="You are not authorized to access this resource on FloydHub."):
+        super(AuthorizationException, self).__init__(message=message)
+
+
+class NotFoundException(FloydException):
+
+    def __init__(self, message="The resource you are looking for was not found. Check if the id is correct."):
         super(NotFoundException, self).__init__(message=message)
 
 
-class BadRequestException(ClickException):
+class BadRequestException(FloydException):
 
-    def __init__(self, message="One or more request parameter is incorrect."):
+    def __init__(self, message="One or more request parameters is incorrect."):
         super(BadRequestException, self).__init__(message=message)
 
 
-class OverLimitException(ClickException):
+class OverLimitException(FloydException):
 
     def __init__(self, message="You are over the allowed limits for this operation. Consider upgrading your account."):
         super(OverLimitException, self).__init__(message=message)
+
+
+class ServerException(FloydException):
+
+    def __init__(self, message="Internal FloydHub server error."):
+        super(ServerException, self).__init__(message=message)
+
+
+class BadGatewayException(FloydException):
+
+    def __init__(self, message="Invalid response from FloydHub server."):
+        super(BadGatewayException, self).__init__(message=message)
+
+
+class GatewayTimeoutException(FloydException):
+
+    def __init__(self, message="FloydHub server took too long to respond."):
+        super(GatewayTimeoutException, self).__init__(message=message)

--- a/tests/cli/data/delete_test.py
+++ b/tests/cli/data/delete_test.py
@@ -3,6 +3,7 @@ import unittest
 from mock import patch, call
 
 from floyd.cli.data import delete
+from tests.cli.data.mocks import mock_data
 
 
 class TestDataDelete(unittest.TestCase):
@@ -21,22 +22,20 @@ class TestDataDelete(unittest.TestCase):
 
         assert(result.exit_code == 0)
 
-    @patch('floyd.cli.data.DataClient.get')
+    @patch('floyd.cli.data.DataClient.get', side_effect=mock_data)
     @patch('floyd.cli.data.DataClient.delete', return_value=True)
     def test_with_multiple_ids_and_yes_option(self, delete_data, get_data):
         id_1, id_2, id_3 = '1', '2', '3'
         result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
 
-        # Doesn't send a get before attempting to delete
-        get_data.assert_not_called()
-
-        # Trigger a delete for each id
+        # Trigger a get and a delete for each id
         calls = [call(id_1), call(id_2), call(id_3)]
+        get_data.assert_has_calls(calls, any_order=True)
         delete_data.assert_has_calls(calls, any_order=True)
 
         assert(result.exit_code == 0)
 
-    @patch('floyd.cli.data.DataClient.get')
+    @patch('floyd.cli.data.DataClient.get', side_effect=mock_data)
     @patch('floyd.cli.data.DataClient.delete', return_value=True)
     def test_delete_without_yes_option(self, delete_data, get_data):
         id_1, id_2, id_3 = '1', '2', '3'
@@ -46,27 +45,42 @@ class TestDataDelete(unittest.TestCase):
                                     [id_1, id_2, id_3],
                                     input='n\nY\nn\n')
 
-        # Doesn't send a get before attempting to delete
-        get_data.assert_not_called()
+        # Triggers a get for all ids
+        calls = [call(id_1), call(id_2), call(id_3)]
+        get_data.assert_has_calls(calls, any_order=True)
 
         # Calls delete for only id_2
         delete_data.assert_called_once_with(id_2)
 
         assert(result.exit_code == 0)
 
-    @patch('floyd.cli.data.DataClient.get')
+    @patch('floyd.cli.data.DataClient.get', side_effect=mock_data)
     @patch('floyd.cli.data.DataClient.delete', return_value=False)
     def test_failed_delete(self, delete_data, get_data):
         id_1, id_2, id_3 = '1', '2', '3'
         result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
 
-        # Doesn't send a get before attempting to delete
-        get_data.assert_not_called()
-
-        # Trigger a delete for each id, even though each delete
+        # Trigger a get and a delete for each id, even though each delete
         # fails. All deletes are attempted regardless of previous failures.
         calls = [call(id_1), call(id_2), call(id_3)]
+        get_data.assert_has_calls(calls, any_order=True)
         delete_data.assert_has_calls(calls, any_order=True)
 
         # Exit 1 for failed deletes
+        assert(result.exit_code == 1)
+
+    @patch('floyd.cli.data.DataClient.get', return_value=None)
+    @patch('floyd.cli.data.DataClient.delete')
+    def test_failed_get(self, delete_data, get_data):
+        id_1, id_2, id_3 = '1', '2', '3'
+        result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
+
+        # Trigger a get for each id, even though each fails. (No early exit)
+        calls = [call(id_1), call(id_2), call(id_3)]
+        get_data.assert_has_calls(calls, any_order=True)
+
+        # Deletes are not triggered for ids that are not found
+        delete_data.assert_not_called()
+
+        # Exit 1 for failed get requests
         assert(result.exit_code == 1)

--- a/tests/cli/data/delete_test.py
+++ b/tests/cli/data/delete_test.py
@@ -1,0 +1,70 @@
+from click.testing import CliRunner
+import unittest
+from mock import patch, call
+
+from floyd.cli.data import delete
+from tests.cli.data.mocks import mock_data
+
+
+class TestDataDelete(unittest.TestCase):
+    """
+    Tests CLI's data delete functionality `floyd data delete`
+    """
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch('floyd.cli.data.DataClient')
+    def test_with_no_arguments(self, data_client):
+        result = self.runner.invoke(delete)
+
+        # No calls to api, exit 0
+        data_client.assert_not_called()
+
+        assert(result.exit_code == 0)
+
+    @patch('floyd.cli.data.DataClient.get')
+    @patch('floyd.cli.data.DataClient.delete', side_effect=mock_data)
+    def test_with_multiple_ids_and_yes_option(self, delete_data, get_data):
+        id_1, id_2, id_3 = '1', '2', '3'
+        result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
+
+        # Trigger a get and a delete for each id
+        calls = [call(id_1), call(id_2), call(id_3)]
+        get_data.assert_has_calls(calls, any_order=True)
+        delete_data.assert_has_calls(calls, any_order=True)
+
+        assert(result.exit_code == 0)
+
+    @patch('floyd.cli.data.DataClient.get')
+    @patch('floyd.cli.data.DataClient.delete', side_effect=mock_data)
+    def test_delete_without_yes_option(self, delete_data, get_data):
+        id_1, id_2, id_3 = '1', '2', '3'
+
+        # Tell prompt to skip id_1 and id_3
+        result = self.runner.invoke(delete,
+                                    [id_1, id_2, id_3],
+                                    input='n\nY\nn\n')
+
+        # Triggers a get for all ids
+        calls = [call(id_1), call(id_2), call(id_3)]
+        get_data.assert_has_calls(calls, any_order=True)
+
+        # Calls delete for only id_2
+        delete_data.assert_called_once_with(id_2)
+
+        assert(result.exit_code == 0)
+
+    @patch('floyd.cli.data.DataClient.get')
+    @patch('floyd.cli.data.DataClient.delete', return_value=False)
+    def test_failed_delete(self, delete_data, get_data):
+        id_1, id_2, id_3 = '1', '2', '3'
+        result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
+
+        # Trigger a get and a delete for each id, even though each delete
+        # fails. All deletes are attempted regardless of previous failures.
+        calls = [call(id_1), call(id_2), call(id_3)]
+        get_data.assert_has_calls(calls, any_order=True)
+        delete_data.assert_has_calls(calls, any_order=True)
+
+        # Exit 1 for failed deletes
+        assert(result.exit_code == 1)

--- a/tests/cli/data/delete_test.py
+++ b/tests/cli/data/delete_test.py
@@ -3,7 +3,6 @@ import unittest
 from mock import patch, call
 
 from floyd.cli.data import delete
-from tests.cli.data.mocks import mock_data
 
 
 class TestDataDelete(unittest.TestCase):
@@ -22,20 +21,22 @@ class TestDataDelete(unittest.TestCase):
 
         assert(result.exit_code == 0)
 
-    @patch('floyd.cli.data.DataClient.get', side_effect=mock_data)
+    @patch('floyd.cli.data.DataClient.get')
     @patch('floyd.cli.data.DataClient.delete', return_value=True)
     def test_with_multiple_ids_and_yes_option(self, delete_data, get_data):
         id_1, id_2, id_3 = '1', '2', '3'
         result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
 
-        # Trigger a get and a delete for each id
+        # Doesn't send a get before attempting to delete
+        get_data.assert_not_called()
+
+        # Trigger a delete for each id
         calls = [call(id_1), call(id_2), call(id_3)]
-        get_data.assert_has_calls(calls, any_order=True)
         delete_data.assert_has_calls(calls, any_order=True)
 
         assert(result.exit_code == 0)
 
-    @patch('floyd.cli.data.DataClient.get', side_effect=mock_data)
+    @patch('floyd.cli.data.DataClient.get')
     @patch('floyd.cli.data.DataClient.delete', return_value=True)
     def test_delete_without_yes_option(self, delete_data, get_data):
         id_1, id_2, id_3 = '1', '2', '3'
@@ -45,42 +46,27 @@ class TestDataDelete(unittest.TestCase):
                                     [id_1, id_2, id_3],
                                     input='n\nY\nn\n')
 
-        # Triggers a get for all ids
-        calls = [call(id_1), call(id_2), call(id_3)]
-        get_data.assert_has_calls(calls, any_order=True)
+        # Doesn't send a get before attempting to delete
+        get_data.assert_not_called()
 
         # Calls delete for only id_2
         delete_data.assert_called_once_with(id_2)
 
         assert(result.exit_code == 0)
 
-    @patch('floyd.cli.data.DataClient.get', side_effect=mock_data)
+    @patch('floyd.cli.data.DataClient.get')
     @patch('floyd.cli.data.DataClient.delete', return_value=False)
     def test_failed_delete(self, delete_data, get_data):
         id_1, id_2, id_3 = '1', '2', '3'
         result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
 
-        # Trigger a get and a delete for each id, even though each delete
+        # Doesn't send a get before attempting to delete
+        get_data.assert_not_called()
+
+        # Trigger a delete for each id, even though each delete
         # fails. All deletes are attempted regardless of previous failures.
         calls = [call(id_1), call(id_2), call(id_3)]
-        get_data.assert_has_calls(calls, any_order=True)
         delete_data.assert_has_calls(calls, any_order=True)
 
         # Exit 1 for failed deletes
-        assert(result.exit_code == 1)
-
-    @patch('floyd.cli.data.DataClient.get', return_value=None)
-    @patch('floyd.cli.data.DataClient.delete')
-    def test_failed_get(self, delete_data, get_data):
-        id_1, id_2, id_3 = '1', '2', '3'
-        result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
-
-        # Trigger a get for each id, even though each fails. (No early exit)
-        calls = [call(id_1), call(id_2), call(id_3)]
-        get_data.assert_has_calls(calls, any_order=True)
-
-        # Deletes are not triggered for ids that are not found
-        delete_data.assert_not_called()
-
-        # Exit 1 for failed get requests
         assert(result.exit_code == 1)

--- a/tests/cli/data/mocks.py
+++ b/tests/cli/data/mocks.py
@@ -1,0 +1,5 @@
+def mock_data(data_id):
+    class Data:
+        id = data_id
+        name = 'test name'
+    return Data()

--- a/tests/cli/data/mocks.py
+++ b/tests/cli/data/mocks.py
@@ -1,5 +1,0 @@
-def mock_data(data_id):
-    class Data:
-        id = data_id
-        name = 'test name'
-    return Data()


### PR DESCRIPTION
# Notes on these changes:

## No early exit for failed deletes
If one of the ids fails to delete, this approach still attempts to delete the other ids, but will have an exit status of 1. This is similar to docker's `rmi` approach to image deletion.

## Move logging and error handing for API calls into Client Classes
I didn't notice this when making the changes in #14, but issues #17 and #18 got me thinking about how to start handling failed API calls and their associated log messages more gracefully. Fundamentally, log messages and exception handling for requests to the API are the responsibility of the Client class (DataClient in this case), so I moved those tasks over there in these changes. I noticed that we are doing some logging in some Client classes already ([here](https://github.com/floydhub/floyd-cli/blob/master/floyd/client/data.py#L49) for example). The re-usability and consistency that gives is nice, and it cleans up the logic in the cli classes. Let me know what you think of this approach.

## ~~Don't GET a data ID before calling DELETE on it~~
~~I noticed that the only reason we get a data id before deleting it is so we can reference its name. We don't allow deletion by name anyways, so I thought it could be good to just remove reference to the name altogether. It's a bit confusing to tell the cli to delete something by id: `floyd data delete 12345`, and then have the cli tell you something like `Data username/data_name: Deleted`.~~

~~This somewhat awkward mix of name and id will be highlighted if we decide to continue to move toward handling API request logging and error handling in the Client classes, as some of the methods take only ids anyways (like `DataClient().delete(id)`, for example. Thoughts, @narenst? If we want to keep the old approach, it's an easy revert of my last commit.~~