### PR TITLE
Feature/delete exp improvements

### DIFF
--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -181,11 +181,13 @@ def delete(ids, yes):
         task_instance_id = get_module_task_instance_id(experiment.task_instances)
         task_instance = TaskInstanceClient().get(task_instance_id) if task_instance_id else None
 
-        if task_instance and task_instance.module_id:
-            ModuleClient().delete(task_instance.module_id)
-
         if not ExperimentClient().delete(id):
             failures = True
+            continue
+
+        if task_instance and task_instance.module_id:
+            if not ModuleClient().delete(task_instance.module_id):
+                failures = True
 
     if failures:
         sys.exit(1)

--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -2,6 +2,7 @@ import click
 import webbrowser
 from tabulate import tabulate
 from time import sleep
+import sys
 
 import floyd
 from floyd.cli.utils import get_task_url, get_module_task_instance_id
@@ -164,26 +165,27 @@ def delete(ids, yes):
     """
     Delete project runs
     """
-    
+    failures = False
     for id in ids:
         experiment = ExperimentClient().get(id)
-        task_instance_id = get_module_task_instance_id(experiment.task_instances)
-        task_instance = TaskInstanceClient().get(task_instance_id) if task_instance_id else None
-
-
-        if experiment.state in ["queued", "running"]:
-            floyd_logger.info("Experiment {}: In {} state and cannot be deleted. Stop it first".format(experiment.name, experiment.state))
+        if not experiment:
+            failures = True
             continue
 
-        if not yes:
-            if not click.confirm("Delete Run: {}?".format(experiment.name), abort=False, default=False):
-                floyd_logger.info("Experiment {}: Skipped.".format(experiment.name))
-                continue
+        if not yes and not click.confirm("Delete Run: {}?".format(experiment.name),
+                                         abort=False,
+                                         default=False):
+            floyd_logger.info("Experiment {}: Skipped.".format(experiment.name))
+            continue
+
+        task_instance_id = get_module_task_instance_id(experiment.task_instances)
+        task_instance = TaskInstanceClient().get(task_instance_id) if task_instance_id else None
 
         if task_instance and task_instance.module_id:
             ModuleClient().delete(task_instance.module_id)
 
-        if ExperimentClient().delete(id):
-            floyd_logger.info("Experiment {}: Deleted".format(experiment.name))
-        else:
-            floyd_logger.error("Experiment {}: Failed to delete experiment")
+        if not ExperimentClient().delete(id):
+            failures = True
+
+    if failures:
+        sys.exit(1)

--- a/floyd/client/module.py
+++ b/floyd/client/module.py
@@ -6,6 +6,7 @@ from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
 from floyd.client.base import FloydHttpClient
 from floyd.client.files import get_files_in_directory
+from floyd.exceptions import FloydException
 from floyd.log import logger as floyd_logger
 
 
@@ -57,6 +58,10 @@ class ModuleClient(FloydHttpClient):
         return response.json().get("id")
 
     def delete(self, id):
-        self.request("DELETE",
-                     "{}{}".format(self.url, id))
-        return True
+        try:
+            self.request("DELETE",
+                         "{}{}".format(self.url, id))
+            return True
+        except FloydException as e:
+            floyd_logger.info("Module {}: ERROR! {}".format(id, e.message))
+            return False

--- a/floyd/client/task_instance.py
+++ b/floyd/client/task_instance.py
@@ -1,5 +1,7 @@
 from floyd.client.base import FloydHttpClient
 from floyd.model.task_instance import TaskInstance
+from floyd.exceptions import FloydException
+from floyd.log import logger as floyd_logger
 
 
 class TaskInstanceClient(FloydHttpClient):
@@ -11,8 +13,12 @@ class TaskInstanceClient(FloydHttpClient):
         super(TaskInstanceClient, self).__init__()
 
     def get(self, id):
-        response = self.request("GET",
-                                "{}{}".format(self.url, id))
-        task_instance_dict = response.json()
-        ti = TaskInstance.from_dict(task_instance_dict)
-        return ti
+        try:
+            response = self.request("GET",
+                                    "{}{}".format(self.url, id))
+            task_instance_dict = response.json()
+            ti = TaskInstance.from_dict(task_instance_dict)
+            return ti
+        except FloydException as e:
+            floyd_logger.info("Task Instance {}: ERROR! {}".format(id, e.message))
+            return None

--- a/tests/cli/experiment/delete_test.py
+++ b/tests/cli/experiment/delete_test.py
@@ -3,7 +3,7 @@ import unittest
 from mock import patch, call
 
 from floyd.cli.experiment import delete
-from tests.cli.mocks import mock_exp, mock_running_exp, mock_queued_exp
+from tests.cli.mocks import mock_exp
 
 
 class TestExperimentDelete(unittest.TestCase):
@@ -79,54 +79,38 @@ class TestExperimentDelete(unittest.TestCase):
 
     @patch('floyd.cli.experiment.TaskInstanceClient')
     @patch('floyd.cli.experiment.ModuleClient')
-    @patch('floyd.cli.experiment.ExperimentClient.get',
-           side_effect=mock_queued_exp)
-    @patch('floyd.cli.experiment.ExperimentClient.delete')
-    def test_delete_with_queued_experiments(self,
-                                            delete_experiment,
-                                            get_experiment,
-                                            module_client,
-                                            task_instance_client):
-        id_1, id_2 = '1', '2'
+    @patch('floyd.cli.experiment.ExperimentClient.get', side_effect=mock_exp)
+    @patch('floyd.cli.experiment.ExperimentClient.delete', return_value=False)
+    def test_failed_delete(self, delete_experiment, get_experiment,
+                           task_instance_client, module_client):
+        id_1, id_2, id_3 = '1', '2', '3'
+        result = self.runner.invoke(delete, ['-y', id_1, id_2, id_3])
 
-        result = self.runner.invoke(delete, ['-y', id_1, id_2])
-
-        # Triggers a get for all ids
-        calls = [call(id_1), call(id_2)]
+        # Trigger a get and a delete for each id, even though each delete
+        # fails. All deletes are attempted regardless of previous failures.
+        calls = [call(id_1), call(id_2), call(id_3)]
         get_experiment.assert_has_calls(calls, any_order=True)
+        delete_experiment.assert_has_calls(calls, any_order=True)
 
-        # Does not call TaskInstanceClient or ModuleClient
-        task_instance_client.assert_not_called()
-        module_client.assert_not_called()
+        # Exit 1 for failed deletes
+        assert(result.exit_code == 1)
 
-        # Does not attempt to delete
-        delete_experiment.assert_not_called()
-
-        assert(result.exit_code == 0)
-
-    @patch('floyd.cli.experiment.TaskInstanceClient')
+    @patch('floyd.cli.experiment.TaskInstanceClient.get', return_value=False)
+    @patch('floyd.cli.experiment.get_module_task_instance_id', return_value='123')
     @patch('floyd.cli.experiment.ModuleClient')
-    @patch('floyd.cli.experiment.ExperimentClient.get',
-           side_effect=mock_running_exp)
-    @patch('floyd.cli.experiment.ExperimentClient.delete')
-    def test_delete_with_running_experiments(self,
-                                             delete_experiment,
-                                             get_experiment,
-                                             module_client,
-                                             task_instance_client):
-        id_1, id_2 = '1', '2'
+    @patch('floyd.cli.experiment.ExperimentClient')
+    def test_with_no_found_task_instance(self,
+                                         experiment_client,
+                                         module_client,
+                                         get_module_task_instance_id,
+                                         get_task_instance):
+        id_1 = '1'
+        result = self.runner.invoke(delete, ['-y', id_1])
 
-        result = self.runner.invoke(delete, ['-y', id_1, id_2])
-
-        # Triggers a get for all ids
-        calls = [call(id_1), call(id_2)]
-        get_experiment.assert_has_calls(calls, any_order=True)
-
-        # Does not call TaskInstanceClient or ModuleClient
-        task_instance_client.assert_not_called()
+        # If a task instance is not found, ModuleClient is not called
+        get_module_task_instance_id.assert_called_once()
+        get_task_instance.assert_called_once_with('123')
         module_client.assert_not_called()
 
-        # Does not attempt to delete
-        delete_experiment.assert_not_called()
-
+        # Exit 0 for successful experiment delete
         assert(result.exit_code == 0)

--- a/tests/cli/experiment/delete_test.py
+++ b/tests/cli/experiment/delete_test.py
@@ -91,7 +91,7 @@ class TestExperimentDelete(unittest.TestCase):
         # Exit 1 for failed deletes
         assert(result.exit_code == 1)
 
-    @patch('floyd.cli.experiment.TaskInstanceClient.get', return_value=False)
+    @patch('floyd.cli.experiment.TaskInstanceClient.get', return_value=None)
     @patch('floyd.cli.experiment.get_module_task_instance_id', return_value='123')
     @patch('floyd.cli.experiment.ModuleClient')
     @patch('floyd.cli.experiment.ExperimentClient')

--- a/tests/cli/experiment/delete_test.py
+++ b/tests/cli/experiment/delete_test.py
@@ -131,3 +131,26 @@ class TestExperimentDelete(unittest.TestCase):
 
         # Exit 0 for successful experiment delete
         assert(result.exit_code == 0)
+
+    @patch('floyd.cli.experiment.TaskInstanceClient.get', side_effect=mock_task_inst)
+    @patch('floyd.cli.experiment.get_module_task_instance_id', return_value='123')
+    @patch('floyd.cli.experiment.ModuleClient.delete')
+    @patch('floyd.cli.experiment.ExperimentClient.delete', return_value=False)
+    @patch('floyd.cli.experiment.ExperimentClient.get')
+    def test_does_not_del_module_if_exp_del_fails(self,
+                                                  get_experiment,
+                                                  delete_experiment,
+                                                  delete_module,
+                                                  get_module_task_instance_id,
+                                                  get_task_instance):
+        id_1 = '1'
+        result = self.runner.invoke(delete, ['-y', id_1])
+
+        # Call delete on the experiment
+        delete_experiment.assert_called_once()
+
+        # Do not attempt to delete the module after a failed delete
+        delete_module.assert_not_called()
+
+        # Exit 1 for failed experiment delete
+        assert(result.exit_code == 1)

--- a/tests/cli/mocks.py
+++ b/tests/cli/mocks.py
@@ -11,24 +11,6 @@ def mock_exp(exp_id):
     return Experiment()
 
 
-def mock_running_exp(exp_id):
-    class Experiment:
-        id = exp_id
-        state = 'running'
-        name = 'running experiment'
-        task_instances = []
-    return Experiment()
-
-
-def mock_queued_exp(exp_id):
-    class Experiment:
-        id = exp_id
-        state = 'queued'
-        name = 'queued experiment'
-        task_instances = []
-    return Experiment()
-
-
 def mock_experiment_config():
     return ExperimentConfig(name="name", family_id="family_id")
 

--- a/tests/cli/mocks.py
+++ b/tests/cli/mocks.py
@@ -11,6 +11,12 @@ def mock_exp(exp_id):
     return Experiment()
 
 
+def mock_task_inst(exp_id):
+    class TaskInstance:
+        module_id = '999999'
+    return TaskInstance()
+
+
 def mock_experiment_config():
     return ExperimentConfig(name="name", family_id="family_id")
 


### PR DESCRIPTION
# Notes on these chages:

## Start to move API call logging and error handling to Client classes
Similar to changes made for the DataClient in #21. Just cleaning up calls related to deleting experiments as the code is fresh in my mind.

## Handling 404s for queued and running experiments
The DELETE experiment API endpoint will return a 404 for an experiement that doesn't exist, but also for queued and running experiments. For this reason, the error message that the ExperimentClient logs for a 404 includes information about all three of those possibilities, and is a bit wordy.  If you want to keep the check for 'queued' and 'running' states in the cli and clean up the log message, I can do that. Maybe a different HTTP status for queued/running experiments (422 maybe?) would be good in the future. But for now, this works just fine.