### PR TITLE
Fix failing install with some pip versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "shortuuid>=0.4.3",
         "tabulate>=0.7.7",
         "pathlib2>=2.2.1",
-        "backports.tempfile",
+        "backports.tempfile>=1.0rc1",
     ],
     setup_requires=[
         "nose>=1.0",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "tabulate>=0.7.7",
         "pathlib2>=2.2.1",
         "backports.tempfile>=1.0rc1",
+        "backports.weakref>=1.0rc1",
     ],
     setup_requires=[
         "nose>=1.0",


### PR DESCRIPTION
## Not Ready to Merge (see update below)

Some `pip` versions will fail to install `floyd-cli` if the `--pre` flag isn't passed, since we rely on `backports.tempfile`, which [only has a 1.0rc1](https://pypi.python.org/simple/backports.tempfile/) release at the moment.

From the [pip docs](https://pip.pypa.io/en/stable/reference/pip_install/#pre-release-versions):

> Starting with v1.4, pip will only install stable versions as specified
> by PEP426 by default. If a version cannot be parsed as a compliant
> PEP426 version then it is assumed to be a pre-release.
> 
> If a Requirement specifier includes a pre-release or development version
> (e.g. >=0.0.dev0) then pip will allow pre-release and development
> versions for that requirement.

While the behaviors of different `pip` versions differ with regard to pre-release versions, [this gist](https://gist.github.com/mckayward/7e83668a7bf74a3712c99e4dc6a71430) has a Dockerfile that can be used to reproduce a failed install. It uses the default Python (v2.7.6) and pip (v1.5.4) on Ubuntu 14.04 LTS, which some people out there are probably still using.

It's interesting that some newer versions actually deviate from what the quoted portion of the `pip` docs say, but regardless, there are still `pip` versions out there that require the `--pre` flag to install `floyd-cli`.

I figured it was only a matter of time before somebody logs an issue for this. Let me know your thoughts, @narenst

## Update

I tried to set up a test for this using testpypi, and found out that `backports.tempfile` relies on another package that only has pre-release versions, so the install still fails. Perhaps we should just update the docs to say we should pass the `--pre` flag to `pip install`? We could also just roll this ourselves, refactor the small part of our code that uses it, or call out the other dependency as `>=1.0rc1` too in our setup.py. I'll take a closer look at our options.