### PR TITLE
Remove / prefix on .floydignore patterns

### DIFF
--- a/floyd/manager/floyd_ignore.py
+++ b/floyd/manager/floyd_ignore.py
@@ -24,6 +24,15 @@ class FloydIgnoreManager(object):
 
     @classmethod
     def get_lists(cls, config_file_path=None):
+        # Remove a preceding '/'. The glob matcher we use will interpret a
+        # pattern starging with a '/' as an absolute path, so we remove the
+        # '/'. For details on the glob matcher, see:
+        # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.match
+        def trim_slash_prefix(path):
+            if path.startswith('/'):
+                return line[1:]
+            return line
+
         config_file_path = config_file_path or cls.CONFIG_FILE_PATH
 
         if not os.path.isfile(config_file_path):
@@ -38,7 +47,8 @@ class FloydIgnoreManager(object):
                     continue
 
                 if line.startswith('!'):
-                    whitelist.append(line[1:])
+                    line = line[1:]
+                    whitelist.append(trim_slash_prefix(line))
                     continue
 
                 # To allow escaping file names that start with !, #, or \,
@@ -46,6 +56,6 @@ class FloydIgnoreManager(object):
                 if line.startswith('\\'):
                     line = line[1:]
 
-                ignore_list.append(line)
+                ignore_list.append(trim_slash_prefix(line))
 
         return (ignore_list, whitelist)

--- a/tests/manager/floyd_ignore/get_lists_test.py
+++ b/tests/manager/floyd_ignore/get_lists_test.py
@@ -19,6 +19,16 @@ class TestFloydIgnoreManagerGetLists(unittest.TestCase):
 
     @patch('floyd.manager.floyd_ignore.os.path.isfile', return_value=True)
     @patch('floyd.manager.floyd_ignore.open', new_callable=mock_open)
+    def test_trims_slash_prefix_from_abs_paths(self, mopen, _):
+        # Manually mock the iterator that imitates the lines read from the file
+        file_data = ['/hello', '!/world']
+        mopen.return_value.__iter__.return_value = file_data
+
+        result = FloydIgnoreManager.get_lists()
+        self.assertEqual(result, (['hello'], ['world']))
+
+    @patch('floyd.manager.floyd_ignore.os.path.isfile', return_value=True)
+    @patch('floyd.manager.floyd_ignore.open', new_callable=mock_open)
     def test_properly_interprets_whitelisted_globs(self, mopen, _):
         # Manually mock the iterator that imitates the lines read from the file
         file_data = ['', '# comment', '*.py', '!hello.py']


### PR DESCRIPTION
@houqp @narenst

I was updating the docs for floydignore logic to include the new changes released today and I discovered a bug that will affect many users:

Patterns starting with a `/` don't match directories.

We use [`PurePath.match()`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.match) to match glob patterns for .floydignore. Its docs state that a pattern with a preceding '/' will be interpreted as an absolute path and will only match against absolute paths.

By removing the `/` prefix when parsing the glob patterns, we get the desired matching behavior.