### PR TITLE
Bump version: 0.9.8 → 0.9.9

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.8
+current_version = 0.9.9
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import find_packages, setup
 
 project = "floyd-cli"
-version = "0.9.8"
+version = "0.9.9"
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     long_description = readme.read()


### PR DESCRIPTION
retag cli for new release, previous version was deleted from pypi