### PR TITLE
Fixes the issue with job and data outputs

### DIFF
--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -6,6 +6,7 @@ import webbrowser
 import floyd
 from floyd.client.data import DataClient
 from floyd.client.dataset import DatasetClient
+from floyd.client.resource import ResourceClient
 from floyd.manager.auth_config import AuthConfigManager
 from floyd.manager.data_config import DataConfig, DataConfigManager
 from floyd.log import logger as floyd_logger
@@ -133,8 +134,8 @@ def output(id, url):
     if not data_source:
         sys.exit()
 
-    data_url = "{}/api/v1/resources/{}?content=true".format(floyd.floyd_host,
-                                                            data_source.resource_id)
+    resource = ResourceClient().get(data_source.resource_id)
+    data_url = "{}/viewer/{}".format(floyd.floyd_host, resource.uri)
     if url:
         floyd_logger.info(data_url)
     else:

--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -169,8 +169,8 @@ def output(id, url, download):
     experiment = ExperimentClient().get(id)
     task_instance = TaskInstanceClient().get(get_module_task_instance_id(experiment.task_instances))
     if "output" in task_instance.output_ids:
-        output_dir_url = "{}/api/v1/resources/{}?content=true".format(floyd.floyd_host,
-                                                                      task_instance.output_ids["output"])
+        resource = ResourceClient().get(task_instance.output_ids["output"])
+        output_dir_url = "{}/viewer/{}".format(floyd.floyd_host, resource.uri)
         if url:
             floyd_logger.info(output_dir_url)
         else:

--- a/floyd/client/resource.py
+++ b/floyd/client/resource.py
@@ -20,7 +20,8 @@ class ResourceClient(FloydHttpClient):
         try:
             response = self.request('GET', self.URL_PREFIX + resource_id)
             resource_dict = response.json()
-            return Resource.from_dict(resource_dict)
+            resource = Resource.from_dict(resource_dict)
+            return resource
         except FloydException as e:
             floyd_logger.info("Resource %s: ERROR! %s", resource_id, e.message)
             return None

--- a/floyd/model/resource.py
+++ b/floyd/model/resource.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, post_load
 from floyd.model.base import BaseModel
 
 
@@ -11,19 +11,23 @@ class ResourceSchema(Schema):
     date_finalized = fields.DateTime()
     date_last_updated = fields.DateTime()
 
+    @post_load
+    def make_resource(self, data):
+        return Resource(**data)
+
 
 class Resource(BaseModel):
     schema = ResourceSchema(strict=True)
 
     def __init__(self,
-                 resource_id,
+                 id,
                  uri,
                  state,
                  resource_type,
                  size,
                  date_finalized,
                  date_last_updated):
-        self.id = resource_id
+        self.id = id
         self.uri = uri
         self.state = state
         self.resource_type = resource_type


### PR DESCRIPTION
Use the resource uri to construct the target url in the client.

Since the request has auth, it will no longer automatically redirect to the file viewer.