### PR TITLE
Regression: Handle invalid token error

### DIFF
--- a/floyd/client/auth.py
+++ b/floyd/client/auth.py
@@ -1,5 +1,3 @@
-import requests
-
 import floyd
 from floyd.exceptions import AuthenticationException
 from floyd.client.base import FloydHttpClient
@@ -14,9 +12,9 @@ class AuthClient(FloydHttpClient):
         self.base_url = "{}/api/v1/user/".format(floyd.floyd_host)
 
     def get_user(self, access_token):
-        response = requests.get(self.base_url,
-                                headers={"Authorization": "Bearer {}".format(access_token)})
         try:
+            response = self.requests.get(self.base_url,
+                                         headers={"Authorization": "Bearer {}".format(access_token)})
             user_dict = response.json()
         except Exception:
             raise AuthenticationException("Invalid Token.\nSee http://docs.floydhub.com/faqs/authentication/ for help")


### PR DESCRIPTION
Now that we are returning json for invalid token error the CLI
was throwing this error:

```
  File "/Users/naren/Code/floyd/floyd-cli/floyd/model/user.py", line 14,
  in make_user
      return User(**data)
    TypeError: __init__() missing 4 required positional arguments:
    'uid', 'username', 'email', and 'type'
```

This was because the login client was not using the same base web client
as the other clients.