### PR TITLE
honor --no-open flag in floyd run

### DIFF
--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -72,7 +72,7 @@ def validate_env(env, instance_type):
     return True
 
 
-def show_new_job_info(expt_client, job_name, expt_info, mode):
+def show_new_job_info(expt_client, job_name, expt_info, mode, open_notebook):
     if mode in ['jupyter', 'serve']:
         while True:
             # Wait for the experiment / task instances to become available
@@ -98,7 +98,7 @@ def show_new_job_info(expt_client, job_name, expt_info, mode):
             if wait_for_url(jupyter_url, sleep_duration_seconds=2, iterations=900):
                 sleep(3)  # HACK: sleep extra 3 seconds for traffic route sync
                 floyd_logger.info("\nPath to jupyter notebook: %s", jupyter_url)
-                if open:
+                if open_notebook:
                     webbrowser.open(jupyter_url)
             else:
                 floyd_logger.info("\nPath to jupyter notebook: %s", jupyter_url)
@@ -127,7 +127,7 @@ def show_new_job_info(expt_client, job_name, expt_info, mode):
               help='Different floyd modes',
               default='job',
               type=click.Choice(['job', 'jupyter', 'serve']))
-@click.option('--open/--no-open',
+@click.option('--open/--no-open', 'open_notebook',
               help='Automatically open the notebook url',
               default=True)
 @click.option('--env',
@@ -141,7 +141,7 @@ def show_new_job_info(expt_client, job_name, expt_info, mode):
 @click.option('--cpu+', 'cpup', is_flag=True, help='Run in a CPU+ instance')
 @click.argument('command', nargs=-1)
 @click.pass_context
-def run(ctx, gpu, env, message, data, mode, open, tensorboard, gpup, cpup, command):
+def run(ctx, gpu, env, message, data, mode, open_notebook, tensorboard, gpup, cpup, command):
     """
     Run a command on Floyd. Floyd will upload contents of the
     current directory and run your command remotely.
@@ -227,7 +227,7 @@ def run(ctx, gpu, env, message, data, mode, open, tensorboard, gpup, cpup, comma
     show_new_job_info(expt_client, job_name, expt_info, mode)
 
 
-def get_command_line(instance_type, env, message, data, mode, open, tensorboard, command_str):
+def get_command_line(instance_type, env, message, data, mode, open_notebook, tensorboard, command_str):
     """
     Return a string representing the full floyd command entered in the command line
     """
@@ -245,7 +245,7 @@ def get_command_line(instance_type, env, message, data, mode, open, tensorboard,
     if not mode == "job":
         floyd_command += ["--mode", mode]
         if mode == 'jupyter':
-            if not open:
+            if not open_notebook:
                 floyd_command.append("--no-open")
     else:
         if command_str:

--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -224,7 +224,7 @@ def run(ctx, gpu, env, message, data, mode, open_notebook, tensorboard, gpup, cp
     table_output = [["JOB NAME"], [job_name]]
     floyd_logger.info(tabulate(table_output, headers="firstrow"))
     floyd_logger.info("")
-    show_new_job_info(expt_client, job_name, expt_info, mode)
+    show_new_job_info(expt_client, job_name, expt_info, mode, open_notebook)
 
 
 def get_command_line(instance_type, env, message, data, mode, open_notebook, tensorboard, command_str):
@@ -321,4 +321,4 @@ def restart(ctx, job_name, data, open_notebook, env, message, gpu, cpu, gpup, cp
     table_output = [["JOB NAME"], [new_job_info['name']]]
     floyd_logger.info('\n' + tabulate(table_output, headers="firstrow") + '\n')
 
-    show_new_job_info(expt_client, new_job_info['name'], new_job_info, job.mode)
+    show_new_job_info(expt_client, new_job_info['name'], new_job_info, job.mode, open_notebook)

--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -69,7 +69,7 @@ class TestExperimentRun(unittest.TestCase):
             message='test\' message',
             data=['foo:input'],
             mode='job',
-            open=False,
+            open_notebook=False,
             tensorboard=True,
             command_str='echo hello'
         )
@@ -81,7 +81,7 @@ class TestExperimentRun(unittest.TestCase):
             message=None,
             data=['foo:input', 'bar'],
             mode='jupyter',
-            open=True,
+            open_notebook=True,
             tensorboard=False,
             command_str='echo \'hello'
         )
@@ -93,7 +93,7 @@ class TestExperimentRun(unittest.TestCase):
             message=None,
             data=['foo:input'],
             mode='job',
-            open=False,
+            open_notebook=False,
             tensorboard=True,
             command_str='echo hello > /output'
         )


### PR DESCRIPTION
While writing some tests I learned that the `--no-open` flag for `floyd run` isn't being honored. This fixes it. @houqp @narenst 