### PR TITLE
strip whitespace from access_code on login

### DIFF
--- a/floyd/cli/auth.py
+++ b/floyd/cli/auth.py
@@ -23,6 +23,8 @@ def login(token):
     floyd_logger.info("Please copy and paste the authentication token.")
     access_code = click.prompt('This is an invisible field. Paste token and press ENTER', type=str, hide_input=True)
 
+    access_code = access_code.strip()
+
     if not access_code:
         floyd_logger.info("Empty token received. Make sure your shell is handling the token appropriately.")
         floyd_logger.info("See docs for help: http://docs.floydhub.com/faqs/authentication/")


### PR DESCRIPTION
Our check for `if not access_code:` wasn't really helping much. Click will automatically re-prompt if nothing was entered, and strings of whitespace are truthy in Python. This change brings us closer to the original intent of the check, I think.