### PR TITLE
Include conda as install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "tabulate>=0.7.7",
         "pathlib2>=2.2.1",
         "raven",
+        "conda"
     ],
     setup_requires=[
         "nose>=1.0",


### PR DESCRIPTION
This is crashing when installing last version of floyd-cli and the systems doesnt have conda installed.