### PR TITLE
limit jobs to one --env

### DIFF
--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -101,7 +101,7 @@ class TestExperimentRun(unittest.TestCase):
         assert re == 'floyd run --gpu --env tensorflow --data mckay/datasets/foo/1:input --tensorboard \'echo hello > /output\''
 
     @patch('floyd.model.access_token.assert_token_not_expired')
-    @patch('floyd.cli.run.EnvClient.get_all', return_value={'cpu': {'default': 'bar'}})
+    @patch('floyd.cli.run.EnvClient.get_all', return_value={'cpu': {'foo': 'foo', 'bar': 'bar'}})
     @patch('floyd.cli.run.AuthConfigManager.get_access_token', side_effect=mock_access_token)
     @patch('floyd.cli.run.ExperimentConfigManager.get_config', side_effect=mock_experiment_config)
     @patch('floyd.cli.run.ExperimentConfigManager.set_config')
@@ -120,9 +120,9 @@ class TestExperimentRun(unittest.TestCase):
         """
         CLI should fail if more than one --env is passed
         """
-        result = self.runner.invoke(run, ['--env', 'tensorflow', '--env', 'default', 'ls'])
+        result = self.runner.invoke(run, ['--env', 'foo', '--env', 'bar', 'ls'])
         assert(result.exit_code != 0)
 
-        result = self.runner.invoke(run, ['--env', 'default', 'ls'])
+        result = self.runner.invoke(run, ['--env', 'foo', 'ls'])
         assert(result.exit_code == 0)
 


### PR DESCRIPTION
I fiddled with this for a bit, and it seems like click doesn't allow a built-in way to do this. The solution I have here definitely works, even if a bit hacky.

Let me know if you want anything changed.