### PR TITLE
add readme as description

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ Quick Start
 1.  Install the cli:
 
     Using `pip`:
+
     ```
     $ pip install -U floyd-cli
     ```
+
     Using `conda`:
+
     ```
     $ conda install -y -c conda-forge -c floydhub floyd-cli
     ```

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -64,12 +64,11 @@ test:
 
 about:
   home: https://github.com/floydhub/floyd-cli
-  license: ''
   license_family: AGPL
-  license_file: ''
+  license: Apache
   summary: Command line tool for Floyd
   doc_url: https://docs.floydhub.com
-  dev_url: ''
+  description: README.md
 
 extra:
   recipe-maintainers: 'support@floydhub.com'


### PR DESCRIPTION
These changes will update clean up the anaconda page a bit. I haven't found a way to override the installation instructions :/

https://anaconda.org/mckayward/floyd-cli Shows how this will end up rendering
