### PR TITLE
floyd logs: automatically retry if queued

### DIFF
--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -150,14 +150,21 @@ def logs(id, url, tail, follow, sleep_duration=1):
     Print the logs of the run.
     """
     tail = tail or follow
-    try:
-        experiment = ExperimentClient().get(normalize_job_name(id))
-    except FloydException:
-        experiment = ExperimentClient().get(id)
+    was_queued = False
+    while True:
+        try:
+            experiment = ExperimentClient().get(normalize_job_name(id))
+        except FloydException:
+            experiment = ExperimentClient().get(id)
 
-    if experiment.state == 'queued':
-        floyd_logger.info("Job is currently in a queue")
-        return
+        if experiment.state == 'queued':
+            floyd_logger.info("Job is currently in a queue ...")
+            was_queued = True
+            sleep(1)
+        else:
+            break
+    if was_queued:
+        floyd_logger.info("")  # print a newline
 
     instance_log_id = experiment.instance_log_id
     if not instance_log_id:

--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -165,7 +165,7 @@ def logs(id, url, tail, follow, sleep_duration=1):
             floyd_logger.info("Waiting for logs ...\n")
             log_msg_printed = True
 
-        sleep(0.2)
+        sleep(1)
 
     log_url = "{}/api/v1/resources/{}?content=true".format(
         floyd.floyd_host, instance_log_id)


### PR DESCRIPTION
When running `floyd logs`, if the job is currently in a queue, retry until the job is actually running (sleeping for one second between attempts).