### PR TITLE
Add `floyd data listfiles` and `floyd data getfile` commands

### DIFF
--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -142,6 +142,66 @@ def clone(id):
 
 
 @click.command()
+@click.argument('id', nargs=1)
+def listfiles(id):
+    """
+    List files in the given dataset
+    """
+
+    data_source = DataClient().get(normalize_data_name(id, use_data_config=False))
+    if id and not data_source:
+        # Try with the raw ID
+        data_source = DataClient().get(id)
+
+    if not data_source:
+        if 'output' in id:
+            floyd_logger.info("Note: You cannot clone the output of a running job. You need to wait for it to finish.")
+        sys.exit()
+
+    # Depth-first search
+    dirs = ['']
+    paths = []
+    while dirs:
+        dir = dirs.pop()
+        url = "/resources/{}/{}?content=true".format(data_source.resource_id, dir)
+        files = DataClient().request("GET", url).json()['files']
+        files.sort(key=lambda f: f['name'])
+        for file in files:
+            path = dir + '/' + file['name']
+            if file['type'] == 'directory':
+                path += '/'
+            paths.append(path)
+
+            if file['type'] == 'directory':
+                dirs.append(dir + '/' + file['name'])
+    for path in paths:
+        floyd_logger.info(path)
+
+
+@click.command()
+@click.argument('id', nargs=1)
+@click.argument('path', nargs=1)
+def getfile(id, path):
+    """
+    Get the specified individual file from a dataset
+    """
+
+    data_source = DataClient().get(normalize_data_name(id, use_data_config=False))
+    if id and not data_source:
+        # Try with the raw ID
+        data_source = DataClient().get(id)
+
+    if not data_source:
+        if 'output' in id:
+            floyd_logger.info("Note: You cannot clone the output of a running job. You need to wait for it to finish.")
+        sys.exit()
+
+    url = "{}/api/v1/resources/{}/{}?content=true".format(floyd.floyd_host, data_source.resource_id, path)
+    fname = path.split('/')[-1]
+    DataClient().download(url, filename=fname)
+
+
+@click.command()
 @click.option('-u', '--url', is_flag=True, default=False,
               help='Only print url for viewing data')
 @click.argument('id', nargs=1, required=False)
@@ -228,3 +288,5 @@ data.add_command(upload)
 data.add_command(status)
 data.add_command(output)
 data.add_command(add)
+data.add_command(listfiles)
+data.add_command(getfile)

--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -144,19 +144,19 @@ def clone(id):
 
 
 @click.command()
-@click.argument('dataset_name', nargs=1)
-def listfiles(dataset_name):
+@click.argument('data_name', nargs=1)
+def listfiles(data_name):
     """
     List files in the given dataset
     """
 
-    data_source = DataClient().get(normalize_data_name(dataset_name, use_data_config=False))
-    if dataset_name and not data_source:
+    data_source = DataClient().get(normalize_data_name(data_name, use_data_config=False))
+    if data_name and not data_source:
         # Try with the raw ID
-        data_source = DataClient().get(dataset_name)
+        data_source = DataClient().get(data_name)
 
     if not data_source:
-        if 'output' in dataset_name:
+        if 'output' in data_name:
             floyd_logger.info("Note: You cannot clone the output of a running job. You need to wait for it to finish.")
         sys.exit()
 
@@ -169,37 +169,37 @@ def listfiles(dataset_name):
         response = DataClient().request("GET", url).json()
 
         if response['skipped_files'] > 0:
-            floyd_logger.info("Warning: in directory '{}', {}/{} files skipped (too many files)".format(cur_dir, response['skipped_files'], response['total_files']))
+            floyd_logger.info("Warning: in directory '%s', %s/%s files skipped (too many files)", cur_dir, response['skipped_files'], response['total_files'])
 
         files = response['files']
         files.sort(key=lambda f: f['name'])
-        for file in files:
-            path = os.path.join(cur_dir, file['name'])
-            if file['type'] == 'directory':
+        for f in files:
+            path = os.path.join(cur_dir, f['name'])
+            if f['type'] == 'directory':
                 path += os.sep
             paths.append(path)
 
-            if file['type'] == 'directory':
-                dirs.append(os.path.join(cur_dir, file['name']))
+            if f['type'] == 'directory':
+                dirs.append(os.path.join(cur_dir, f['name']))
     for path in paths:
         floyd_logger.info(path)
 
 
 @click.command()
-@click.argument('dataset_name', nargs=1)
+@click.argument('data_name', nargs=1)
 @click.argument('path', nargs=1)
-def getfile(dataset_name, path):
+def getfile(data_name, path):
     """
     Get the specified individual file from a dataset
     """
 
-    data_source = DataClient().get(normalize_data_name(dataset_name, use_data_config=False))
-    if dataset_name and not data_source:
+    data_source = DataClient().get(normalize_data_name(data_name, use_data_config=False))
+    if data_name and not data_source:
         # Try with the raw ID
-        data_source = DataClient().get(dataset_name)
+        data_source = DataClient().get(data_name)
 
     if not data_source:
-        if 'output' in dataset_name:
+        if 'output' in data_name:
             floyd_logger.info("Note: You cannot clone the output of a running job. You need to wait for it to finish.")
         sys.exit()
 

--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -1,5 +1,7 @@
 import click
 import sys
+import os
+import os.path
 from tabulate import tabulate
 import webbrowser
 
@@ -142,19 +144,19 @@ def clone(id):
 
 
 @click.command()
-@click.argument('id', nargs=1)
-def listfiles(id):
+@click.argument('dataset_name', nargs=1)
+def listfiles(dataset_name):
     """
     List files in the given dataset
     """
 
-    data_source = DataClient().get(normalize_data_name(id, use_data_config=False))
-    if id and not data_source:
+    data_source = DataClient().get(normalize_data_name(dataset_name, use_data_config=False))
+    if dataset_name and not data_source:
         # Try with the raw ID
-        data_source = DataClient().get(id)
+        data_source = DataClient().get(dataset_name)
 
     if not data_source:
-        if 'output' in id:
+        if 'output' in dataset_name:
             floyd_logger.info("Note: You cannot clone the output of a running job. You need to wait for it to finish.")
         sys.exit()
 
@@ -162,42 +164,47 @@ def listfiles(id):
     dirs = ['']
     paths = []
     while dirs:
-        dir = dirs.pop()
-        url = "/resources/{}/{}?content=true".format(data_source.resource_id, dir)
-        files = DataClient().request("GET", url).json()['files']
+        cur_dir = dirs.pop()
+        url = "/resources/{}/{}?content=true".format(data_source.resource_id, cur_dir)
+        response = DataClient().request("GET", url).json()
+
+        if response['skipped_files'] > 0:
+            floyd_logger.info("Warning: in directory '{}', {}/{} files skipped (too many files)".format(cur_dir, response['skipped_files'], response['total_files']))
+
+        files = response['files']
         files.sort(key=lambda f: f['name'])
         for file in files:
-            path = dir + '/' + file['name']
+            path = os.path.join(cur_dir, file['name'])
             if file['type'] == 'directory':
-                path += '/'
+                path += os.sep
             paths.append(path)
 
             if file['type'] == 'directory':
-                dirs.append(dir + '/' + file['name'])
+                dirs.append(os.path.join(cur_dir, file['name']))
     for path in paths:
         floyd_logger.info(path)
 
 
 @click.command()
-@click.argument('id', nargs=1)
+@click.argument('dataset_name', nargs=1)
 @click.argument('path', nargs=1)
-def getfile(id, path):
+def getfile(dataset_name, path):
     """
     Get the specified individual file from a dataset
     """
 
-    data_source = DataClient().get(normalize_data_name(id, use_data_config=False))
-    if id and not data_source:
+    data_source = DataClient().get(normalize_data_name(dataset_name, use_data_config=False))
+    if dataset_name and not data_source:
         # Try with the raw ID
-        data_source = DataClient().get(id)
+        data_source = DataClient().get(dataset_name)
 
     if not data_source:
-        if 'output' in id:
+        if 'output' in dataset_name:
             floyd_logger.info("Note: You cannot clone the output of a running job. You need to wait for it to finish.")
         sys.exit()
 
     url = "{}/api/v1/resources/{}/{}?content=true".format(floyd.floyd_host, data_source.resource_id, path)
-    fname = path.split('/')[-1]
+    fname = os.path.basename(path)
     DataClient().download(url, filename=fname)
 
 


### PR DESCRIPTION
My workflow involves setting off multiple runs with different parameters then examining TensorBoard results from each run. To support automating this, this commit adds `floyd data listfiles` (list all files in a particular dataset) and `floyd data getfile` (download a specific file from a dataset).