### PR TITLE
Add latest metrics value to job status

### DIFF
--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -90,8 +90,14 @@ def print_experiments(experiments):
         expt_list.append([normalize_job_name(experiment.name),
                           experiment.created_pretty, experiment.state,
                           experiment.duration_rounded, experiment.instance_type_trimmed,
-                          experiment.description, experiment.latest_metrics if experiment.latest_metrics else ''])
+                          experiment.description, format_metrics(experiment.latest_metrics)])
     floyd_logger.info(tabulate(expt_list, headers=headers))
+
+
+def format_metrics(latest_metrics):
+    return ', '.join(
+        ["%s=%s" % (k, latest_metrics[k]) for k in sorted(latest_metrics.keys())]
+    ) if latest_metrics else ''
 
 
 @click.command()
@@ -136,7 +142,8 @@ def info(job_name_or_id):
              ["Created", experiment.created_pretty],
              ["Status", experiment.state], ["Duration(s)", experiment.duration_rounded],
              ["Instance", experiment.instance_type_trimmed],
-             ["Description", experiment.description]]
+             ["Description", experiment.description],
+             ["Metrics", format_metrics(experiment.latest_metrics)]]
     if task_instance and task_instance.mode in ['jupyter', 'serving']:
         table.append(["Mode", task_instance.mode])
         table.append(["Url", experiment.service_url])

--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -84,13 +84,13 @@ def print_experiments(experiments):
     """
     Prints expt details in a table. Includes urls and mode parameters
     """
-    headers = ["JOB NAME", "CREATED", "STATUS", "DURATION(s)", "INSTANCE", "DESCRIPTION"]
+    headers = ["JOB NAME", "CREATED", "STATUS", "DURATION(s)", "INSTANCE", "DESCRIPTION", "METRICS"]
     expt_list = []
     for experiment in experiments:
         expt_list.append([normalize_job_name(experiment.name),
                           experiment.created_pretty, experiment.state,
-                          experiment.duration_rounded,
-                          experiment.instance_type_trimmed, experiment.description])
+                          experiment.duration_rounded, experiment.instance_type_trimmed,
+                          experiment.description, experiment.latest_metrics if experiment.latest_metrics else ''])
     floyd_logger.info(tabulate(expt_list, headers=headers))
 
 

--- a/floyd/model/experiment.py
+++ b/floyd/model/experiment.py
@@ -24,6 +24,7 @@ class ExperimentSchema(Schema):
     output_id = fields.Str(load_from="instanceOutputId", allow_none=True)
     instance_log_id = fields.Str(load_from="instanceLogId", allow_none=True)
     timeout_seconds = fields.Integer(allow_none=True)
+    latest_metrics = fields.Dict(load_from="latest_metrics", allow_none=True)
 
     @post_load
     def make_experiment(self, data):
@@ -48,6 +49,7 @@ class Experiment(BaseModel):
                  output_id=None,
                  instance_log_id=None,
                  timeout_seconds=None,
+                 latest_metrics=None,
                  mode=None):
         self.id = id
         self.name = name
@@ -67,6 +69,7 @@ class Experiment(BaseModel):
         self.output_id = output_id
         self.instance_log_id = instance_log_id
         self.timeout_seconds = timeout_seconds
+        self.latest_metrics = latest_metrics
         self.mode = mode
 
     def localize_date(self, date):


### PR DESCRIPTION
This adds a new column to the job status table with the latest values of job metrics:

```
$ floyd status

JOB NAME                                  CREATED     STATUS      DURATION(s)  INSTANCE    DESCRIPTION    METRICS
----------------------------------------  ----------  --------  -------------  ----------  -------------  ---------------------------------------------------------------------
floydlabs/projects/hot-dog-not-hot-dog/3  5 days ago  shutdown            519  c1                         {'val_loss': 0.0414, 'acc': 0.974, 'loss': 0.0897, 'val_acc': 0.9858}
floydlabs/projects/hot-dog-not-hot-dog/2  5 days ago  shutdown             53  c1
floydlabs/projects/hot-dog-not-hot-dog/1  5 days ago  success               3  c1
```