### PR TITLE
Deprecation notice for Jupyter mode 

### DIFF
--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -118,7 +118,10 @@ def show_new_job_info(expt_client, job_name, expt_info, mode, open_notebook=True
     floyd_logger.info("URL to job: %s", job_url)
 
     if mode == 'jupyter':
-        floyd_logger.info("You're using Jupyter notebooks, so we suggest trying out FloydHub Workspaces next: https://docs.floydhub.com/guides/workspace/")
+        floyd_logger.info("\n[!] DEPRECATION NOTICE\n"
+                          "Jupyter mode will be no longer availble after September 15th.\n"
+                          "We suggest you to upgrade your workflow by using FloydHub Workspaces: "
+                          "https://docs.floydhub.com/guides/workspace/.")
 
     if mode in ['jupyter', 'serve']:
         while True:

--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -119,8 +119,8 @@ def show_new_job_info(expt_client, job_name, expt_info, mode, open_notebook=True
 
     if mode == 'jupyter':
         floyd_logger.info("\n[!] DEPRECATION NOTICE\n"
-                          "Jupyter mode will be no longer availble after September 15th.\n"
-                          "We suggest you to upgrade your workflow by using FloydHub Workspaces: "
+                          "Jupyter mode will no longer be supported after September 15th.\n"
+                          "Please migrate your projects to Workspaces: "
                           "https://docs.floydhub.com/guides/workspace/.")
 
     if mode in ['jupyter', 'serve']:


### PR DESCRIPTION
Here's the output:

```bash
...
JOB NAME
-----------------------------
redeipirati/projects/deprecation/999

URL to job: https://www.floydhub.com/redeipirati/projects/deprecation/999

[!] DEPRECATION NOTICE
Jupyter mode will be no longer availble after September 15th.
We suggest you to upgrade your workflow by using FloydHub Workspaces: https://docs.floydhub.com/guides/workspace/.
```