### PR TITLE
Catch permission and Ctrl-C signal during compression

### DIFF
--- a/floyd/cli/data_upload_utils.py
+++ b/floyd/cli/data_upload_utils.py
@@ -59,7 +59,7 @@ def initialize_new_upload(data_config, access_token, description=None):
     data_name = "{}/{}".format(namespace, data_config.name)
 
     # Create tarball of the data using the ID returned from the API
-    # TODO: allow to the users to change folder for the compression
+    # TODO: allow to the users to change directory for the compression
     temp_dir = tempfile.mkdtemp()
     tarball_path = os.path.join(temp_dir, "floydhub_data.tar.gz")
 

--- a/floyd/cli/data_upload_utils.py
+++ b/floyd/cli/data_upload_utils.py
@@ -59,13 +59,13 @@ def initialize_new_upload(data_config, access_token, description=None):
     data_name = "{}/{}".format(namespace, data_config.name)
 
     # Create tarball of the data using the ID returned from the API
+    # TODO: allow to the users to change folder for the compression
     temp_dir = tempfile.mkdtemp()
     tarball_path = os.path.join(temp_dir, "floydhub_data.tar.gz")
 
     floyd_logger.debug("Creating tarfile with contents of current directory: %s",
                        tarball_path)
     floyd_logger.info("Compressing data...")
-    # TODO: purge tarball on Ctrl-C
     create_tarfile(source_dir='.', filename=tarball_path)
 
     # If starting a new upload fails for some reason down the line, we don't

--- a/floyd/client/files.py
+++ b/floyd/client/files.py
@@ -1,6 +1,11 @@
 import os
-from pathlib2 import PurePath
+import sys
 import tarfile
+import tempfile
+import signal
+
+from pathlib2 import PurePath
+from shutil import rmtree
 
 from floyd.manager.floyd_ignore import FloydIgnoreManager
 from floyd.log import logger as floyd_logger
@@ -114,9 +119,33 @@ def sizeof_fmt(num, suffix='B'):
     return "%.1f%s%s" % (num, 'Yi', suffix)
 
 
+def warn_purge_exit(info_msg, filename, exit_msg):
+    """
+    Warn the user that's something went wrong,
+    remove the tarball and provide an exit message.
+    """
+    floyd_logger.info(info_msg)
+    rmtree(os.path.dirname(filename))
+    sys.exit(exit_msg)
+
+
 def create_tarfile(source_dir, filename="/tmp/contents.tar.gz"):
     """
     Create a tar file with the contents of the current directory
     """
-    with tarfile.open(filename, "w:gz") as tar:
-        tar.add(source_dir, arcname=os.path.basename(source_dir))
+    try:
+        # Define the default signal handler for catching: Ctrl-C
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+        with tarfile.open(filename, "w:gz") as tar:
+            tar.add(source_dir, arcname=os.path.basename(source_dir))
+
+    except OSError:  # OSError: [Errno 13] Permission denied
+        warn_purge_exit(info_msg="Permission denied. Removing compressed data...",
+                        filename=filename,
+                        exit_msg=("Permission denied. Make sure to have read permission "
+                        "for each file and subfolder inside your dataset folder."))
+
+    except KeyboardInterrupt:  # Purge tarball on Ctrl-C
+        warn_purge_exit(info_msg="Ctrl-C signal detected: Removing compressed data...",
+                        filename=filename,
+                        exit_msg="Stopped the data upload gracefully.")

--- a/floyd/client/files.py
+++ b/floyd/client/files.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import tarfile
-import tempfile
 import signal
 
 from pathlib2 import PurePath
@@ -143,7 +142,7 @@ def create_tarfile(source_dir, filename="/tmp/contents.tar.gz"):
         warn_purge_exit(info_msg="Permission denied. Removing compressed data...",
                         filename=filename,
                         exit_msg=("Permission denied. Make sure to have read permission "
-                        "for each file and subfolder inside your dataset folder."))
+                                  "for each file and subfolder inside your dataset folder."))
 
     except KeyboardInterrupt:  # Purge tarball on Ctrl-C
         warn_purge_exit(info_msg="Ctrl-C signal detected: Removing compressed data...",

--- a/floyd/client/files.py
+++ b/floyd/client/files.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tarfile
 import signal
+import errno
 
 from pathlib2 import PurePath
 from shutil import rmtree
@@ -138,11 +139,13 @@ def create_tarfile(source_dir, filename="/tmp/contents.tar.gz"):
         with tarfile.open(filename, "w:gz") as tar:
             tar.add(source_dir, arcname=os.path.basename(source_dir))
 
-    except OSError:  # OSError: [Errno 13] Permission denied
-        warn_purge_exit(info_msg="Permission denied. Removing compressed data...",
-                        filename=filename,
-                        exit_msg=("Permission denied. Make sure to have read permission "
-                                  "for each file and subfolder inside your dataset folder."))
+    except OSError as e:
+        # OSError: [Errno 13] Permission denied
+        if e.errno == errno.EACCES:
+            warn_purge_exit(info_msg="Permission denied. Removing compressed data...",
+                            filename=filename,
+                            exit_msg=("Permission denied. Make sure to have read permission "
+                                      "for all the files and directories in the path."))
 
     except KeyboardInterrupt:  # Purge tarball on Ctrl-C
         warn_purge_exit(info_msg="Ctrl-C signal detected: Removing compressed data...",

--- a/floyd/client/files.py
+++ b/floyd/client/files.py
@@ -142,10 +142,12 @@ def create_tarfile(source_dir, filename="/tmp/contents.tar.gz"):
     except OSError as e:
         # OSError: [Errno 13] Permission denied
         if e.errno == errno.EACCES:
+            source_dir = os.getcwd() if source_dir == '.' else source_dir  # Expand cwd
             warn_purge_exit(info_msg="Permission denied. Removing compressed data...",
                             filename=filename,
                             exit_msg=("Permission denied. Make sure to have read permission "
-                                      "for all the files and directories in the path."))
+                                      "for all the files and directories in the path: %s")
+                            % (source_dir))
 
     except KeyboardInterrupt:  # Purge tarball on Ctrl-C
         warn_purge_exit(info_msg="Ctrl-C signal detected: Removing compressed data...",


### PR DESCRIPTION
- [catch permission denied error](https://app.asana.com/0/817307208669065/750539112198237)
- catch Ctrl-C signal during compression and purge tarball file.

I'm not sure about the location of the `warn_purge_exit` function, should it be defined inside the `create_tarfile` function since it will be used only in this context?
