### PR TITLE
enable tensorboard by default

### DIFF
--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -190,6 +190,7 @@ def show_new_job_info(expt_client, job_name, expt_info, mode, open_notebook=True
               type=click.Choice(['job', 'jupyter', 'serve']))
 @click.option('-f', '--follow', is_flag=True, default=False, help='Automatically follow logs')
 @click.option('--tensorboard/--no-tensorboard',
+              default=True,
               help='Enable tensorboard in the job environment')
 @click.option('--cpu', is_flag=True, default=False, help='Run on a CPU instance')
 @click.option('--gpu2', 'gpu2', is_flag=True, help='Run in a GPU2 instance')


### PR DESCRIPTION
This is a really dumb way of achieving our goal of "Enable tensorboard for all jobs". But it does have the added benefit of permitting people to continue entering `--tensorboard` or `--no-tensorboard` to their heart's delight without seeing any angry `No such options` error messages. Thoughts?