### PR TITLE
Catch bad arguments during `floyd [data] init`

### DIFF
--- a/floyd/cli/utils.py
+++ b/floyd/cli/utils.py
@@ -1,6 +1,7 @@
 import pkg_resources
 import sys
 import os
+import re
 
 from floyd.exceptions import FloydException
 from floyd.manager.auth_config import AuthConfigManager
@@ -9,6 +10,8 @@ from floyd.manager.data_config import DataConfigManager
 
 from floyd.constants import DOCKER_IMAGES
 
+# Name or Namespace/Name or Namespace/[datasets|projects]/Name
+NAMESPACE_PATTERN = '^([a-zA-Z0-9\-]+\/?){0,2}?[a-zA-Z0-9\-]+$'
 
 def get_docker_image(env, gpu):
     gpu_cpu = "gpu" if gpu else "cpu"
@@ -221,6 +224,15 @@ def get_namespace_from_name(name):
     or
     <namespace>/<project_name>
     """
+    check_name = re.match('^[a-zA-Z0-9]+\/?', name)
+    if not re.match(NAMESPACE_PATTERN, name):
+        sys.exit(("Argument '%s' doesn't match any recognized pattern:\n"
+                  "\tfloyd [data] init <project_or_dataset_name>\n"
+                  "\tfloyd [data] init <namespace>/<project_or_dataset_name>\n"
+                  "\tfloyd [data] init <namespace>/[projects|dataset]/<project_or_dataset_name>\n"
+                  "\n Note: Argument can contains only alphanumeric and - chars"
+                ) % name)
+
     name_parts = name.split("/", 2)
     if len(name_parts) > 1:
         return name_parts[0], name_parts[-1]

--- a/floyd/cli/utils.py
+++ b/floyd/cli/utils.py
@@ -13,6 +13,7 @@ from floyd.constants import DOCKER_IMAGES
 # Name or Namespace/Name or Namespace/[datasets|projects]/Name
 NAMESPACE_PATTERN = '^([a-zA-Z0-9\-]+\/?){0,2}?[a-zA-Z0-9\-]+$'
 
+
 def get_docker_image(env, gpu):
     gpu_cpu = "gpu" if gpu else "cpu"
     return DOCKER_IMAGES.get(gpu_cpu).get(env)
@@ -224,14 +225,13 @@ def get_namespace_from_name(name):
     or
     <namespace>/<project_name>
     """
-    check_name = re.match('^[a-zA-Z0-9]+\/?', name)
     if not re.match(NAMESPACE_PATTERN, name):
         sys.exit(("Argument '%s' doesn't match any recognized pattern:\n"
                   "\tfloyd [data] init <project_or_dataset_name>\n"
                   "\tfloyd [data] init <namespace>/<project_or_dataset_name>\n"
                   "\tfloyd [data] init <namespace>/[projects|dataset]/<project_or_dataset_name>\n"
                   "\n Note: Argument can contains only alphanumeric and - chars"
-                ) % name)
+                  ) % name)
 
     name_parts = name.split("/", 2)
     if len(name_parts) > 1:


### PR DESCRIPTION
- [[cli] data init crash due to invalid input](https://app.asana.com/0/817307208669065/750539112198242)

E.g. 
```bash
(cli-venv) fh:tmp ReDeiPirati $ floyd data init /
Argument '/' doesn't match any recognized pattern:
	floyd [data] init <project_or_dataset_name>
	floyd [data] init <namespace>/<project_or_dataset_name>
	floyd [data] init <namespace>/[projects|dataset]/<project_or_dataset_name>

 Note: Argument can contains only alphanumeric and - chars
```