### PR TITLE
Regex to catch bad data mount

### DIFF
--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -39,15 +39,16 @@ from floyd.cli.data import get_data_object
 from floyd.cli.experiment import get_log_id, follow_logs
 from floyd.cli.utils import current_project_namespace, read_yaml_config
 
-# DEPRECATED: <data_id>, <data_id>:<mounting_point>
+# DEPRECATED pattern, but still available: <data_id>, <data_id>:<mount_dir>
 DATAID_PATTERN = r'[a-zA-Z0-9\-]+(\:\/?[a-zA-Z0-9\-]+\/?)?'
 
+# All the possible patterns:
 # <dataset_name>
-# or <dataset_name>:<mounting_point>
+# or <dataset_name>:<mount_dir>
 # or <namespace>/[projects|datasets]/<dataset_or_project_name>
-# or <namespace>/[projects|datasets]/<dataset_or_project_name>:<mounting_point>
+# or <namespace>/[projects|datasets]/<dataset_or_project_name>:<mount_dir>
 # or <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>
-# or <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>:<mounting_point>
+# or <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>:<mount_dir>
 DATANAME_PATTERN = r'([a-zA-Z0-9\-]+\/(datasets|projects)\/)?[a-zA-Z0-9\-]+(\/[0-9]+)?(\:\/?[a-zA-Z0-9\-]+\/?)?'
 DATAMOUNT_PATTERN = '^(%s|%s)$' % (DATAID_PATTERN, DATANAME_PATTERN)
 
@@ -66,15 +67,11 @@ def process_data_ids(data_ids):
     for data_name_or_id in data_ids:
         if not re.match(DATAMOUNT_PATTERN, data_name_or_id):
             sys.exit(("Argument '%s' doesn't match any recognized pattern:\n"
-                      "\tfloyd run --data <dataset_name>\n"
-                      "\tfloyd run --data <dataset_name>:<mounting_point>\n"
-                      "\tfloyd run --data <namespace>/[projects|datasets]/<dataset_or_project_name>\n"
-                      "\tfloyd run --data <namespace>/[projects|datasets]/<dataset_or_project_name>:<mounting_point>\n"
-                      "\tfloyd run --data <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>\n"
-                      "\tfloyd run --data <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>:<mounting_point>\n"
-                      "\tfloyd run --data <data_id> (DEPRECATED)\n"
+                      "\tfloyd run --data <namespace>/datasets/<dataset_name>:<mount_dir>\n"
+                      "\tfloyd run --data <namespace>/datasets/<dataset_name>/<version>:<mount_dir>\n"
+                      "\tfloyd run --data <namespace>/projects/<project_name>/<version>:<mount_dir>\n"
                       "\tfloyd run --data <data_id>:<mounting_point> (DEPRECATED)\n"
-                      "\n Note: Argument can contain only alphanumeric and - chars"
+                      "\n Note: Argument can only contain alphanumeric (and hyphen-minus -) characters."
                       ) % data_name_or_id)
         path = None
         if ':' in data_name_or_id:

--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -5,6 +5,7 @@ from time import sleep
 import webbrowser
 import sys
 import yaml
+import re
 try:
     from pipes import quote as shell_quote
 except ImportError:
@@ -38,6 +39,18 @@ from floyd.cli.data import get_data_object
 from floyd.cli.experiment import get_log_id, follow_logs
 from floyd.cli.utils import current_project_namespace, read_yaml_config
 
+# DEPRECATED: <data_id>, <data_id>:<mounting_point>
+DATAID_PATTERN = '[a-zA-Z0-9\-]+(\:\/?[a-zA-Z0-9\-]+\/?)?'
+
+# <dataset_name>
+# or <dataset_name>:<mounting_point>
+# or <namespace>/[projects|datasets]/<dataset_or_project_name>
+# or <namespace>/[projects|datasets]/<dataset_or_project_name><mounting_point>
+# or <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>
+# or <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>:<mounting_point>
+DATANAME_PATTERN = '([a-zA-Z0-9\-]+\/(datasets|projects)\/)?[a-zA-Z0-9\-]+(\/[0-9]+)?(\:\/?[a-zA-Z0-9\-]+\/?)?'
+DATAMOUNT_PATTERN = '^(%s|%s)$' % (DATAID_PATTERN, DATANAME_PATTERN)
+
 
 def process_data_ids(data_ids):
     if len(data_ids) > 5:
@@ -51,6 +64,18 @@ def process_data_ids(data_ids):
     processed_data_ids = []
 
     for data_name_or_id in data_ids:
+        if not re.match(DATAMOUNT_PATTERN, data_name_or_id):
+            sys.exit(("Argument '%s' doesn't match any recognized pattern:\n"
+                      "\tfloyd run --data <dataset_name>\n"
+                      "\tfloyd run --data <dataset_name>:<mounting_point>\n"
+                      "\tfloyd run --data <namespace>/[projects|datasets]/<dataset_or_project_name>\n"
+                      "\tfloyd run --data <namespace>/[projects|datasets]/<dataset_or_project_name>:<mounting_point>\n"
+                      "\tfloyd run --data <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>\n"
+                      "\tfloyd run --data <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>:<mounting_point>\n"
+                      "\tfloyd run --data <data_id> (DEPRECATED)\n"
+                      "\tfloyd run --data <data_id>:<mounting_point> (DEPRECATED)\n"
+                      "\n Note: Argument can contain only alphanumeric and - chars"
+                      ) % data_name_or_id)
         path = None
         if ':' in data_name_or_id:
             data_name_or_id, path = data_name_or_id.split(':')

--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -40,15 +40,15 @@ from floyd.cli.experiment import get_log_id, follow_logs
 from floyd.cli.utils import current_project_namespace, read_yaml_config
 
 # DEPRECATED: <data_id>, <data_id>:<mounting_point>
-DATAID_PATTERN = '[a-zA-Z0-9\-]+(\:\/?[a-zA-Z0-9\-]+\/?)?'
+DATAID_PATTERN = r'[a-zA-Z0-9\-]+(\:\/?[a-zA-Z0-9\-]+\/?)?'
 
 # <dataset_name>
 # or <dataset_name>:<mounting_point>
 # or <namespace>/[projects|datasets]/<dataset_or_project_name>
-# or <namespace>/[projects|datasets]/<dataset_or_project_name><mounting_point>
+# or <namespace>/[projects|datasets]/<dataset_or_project_name>:<mounting_point>
 # or <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>
 # or <namespace>/[projects|datasets]/<dataset_or_project_name>/<version>:<mounting_point>
-DATANAME_PATTERN = '([a-zA-Z0-9\-]+\/(datasets|projects)\/)?[a-zA-Z0-9\-]+(\/[0-9]+)?(\:\/?[a-zA-Z0-9\-]+\/?)?'
+DATANAME_PATTERN = r'([a-zA-Z0-9\-]+\/(datasets|projects)\/)?[a-zA-Z0-9\-]+(\/[0-9]+)?(\:\/?[a-zA-Z0-9\-]+\/?)?'
 DATAMOUNT_PATTERN = '^(%s|%s)$' % (DATAID_PATTERN, DATANAME_PATTERN)
 
 

--- a/floyd/cli/utils.py
+++ b/floyd/cli/utils.py
@@ -11,7 +11,7 @@ from floyd.manager.data_config import DataConfigManager
 from floyd.constants import DOCKER_IMAGES
 
 # Name or Namespace/Name or Namespace/[datasets|projects]/Name
-NAMESPACE_PATTERN = '^([a-zA-Z0-9\-]+\/?){0,2}?[a-zA-Z0-9\-]+$'
+NAMESPACE_PATTERN = r'^([a-zA-Z0-9\-]+\/?){0,2}?[a-zA-Z0-9\-]+$'
 
 
 def get_docker_image(env, gpu):
@@ -230,7 +230,7 @@ def get_namespace_from_name(name):
                   "\tfloyd [data] init <project_or_dataset_name>\n"
                   "\tfloyd [data] init <namespace>/<project_or_dataset_name>\n"
                   "\tfloyd [data] init <namespace>/[projects|dataset]/<project_or_dataset_name>\n"
-                  "\n Note: Argument can contain only alphanumeric and - chars"
+                  "\n Note: Argument can only contain alphanumeric (and hyphen-minus -) characters."
                   ) % name)
 
     name_parts = name.split("/", 2)

--- a/floyd/cli/utils.py
+++ b/floyd/cli/utils.py
@@ -230,7 +230,7 @@ def get_namespace_from_name(name):
                   "\tfloyd [data] init <project_or_dataset_name>\n"
                   "\tfloyd [data] init <namespace>/<project_or_dataset_name>\n"
                   "\tfloyd [data] init <namespace>/[projects|dataset]/<project_or_dataset_name>\n"
-                  "\n Note: Argument can contains only alphanumeric and - chars"
+                  "\n Note: Argument can contain only alphanumeric and - chars"
                   ) % name)
 
     name_parts = name.split("/", 2)


### PR DESCRIPTION
- [[cli] crash in processing data mount ids](https://app.asana.com/0/817307208669065/750539112198233)

```bash
(cli-venv) pirate:cli-test pirate$ floyd run --data https://www.floydhub.com/pirate/datasets/my-data:
Argument 'https://www.floydhub.com/pirate/datasets/my-data:' doesn't match any recognized pattern:
        floyd run --data <dataset_name>
	floyd run --data <dataset_name>:<mounting_point>
	floyd run --data <namespace>/[projects|dataset]/<dataset_or_project_name>
	floyd run --data <namespace>/[projects|dataset]/<dataset_or_project_name>
	floyd run --data <namespace>/[projects|dataset]/<dataset_or_project_name>/<version>
	floyd run --data <namespace>/[projects|dataset]/<dataset_or_project_name>/<version>:<mounting_point>
	floyd run --data <data_id> (DEPRECATED)
	floyd run --data <data_id>:<mounting_point> (DEPRECATED)

 Note: Argument can contain only alphanumeric and - chars
```