### PR TITLE
Feature Request: Download a directory inside the output using cli

### DIFF
--- a/floyd/cli/data.py
+++ b/floyd/cli/data.py
@@ -288,7 +288,7 @@ def add(source):
     Create a new dataset version from the contents of a job.
 
     This will create a new dataset version with the job output.
-    Use the full job name: foo/projects/bar/1/home or foo/projects/bar/1/output
+    Use the full job name: foo/projects/bar/1/code, foo/projects/bar/1/files or foo/projects/bar/1/output
     """
     new_data = DatasetClient().add_data(source)
     print_data([DataClient().get(new_data['data_id'])])

--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -119,14 +119,22 @@ def format_metrics(latest_metrics):
 
 @click.command()
 @click.argument('id', nargs=1)
-@click.option('--directory', '-d',
-              help='Download a directory from Job')
-def clone(id, directory):
+@click.option('--path', '-p',
+              help='Download files in a specific path from a job')
+def clone(id, path):
     """
-    Download files from a job.
+    - Download all files from a job
 
-    This will download the files that were originally uploaded at
+    Eg: alice/projects/mnist/1/
+
+    Note: This will download the files that were originally uploaded at
     the start of the job.
+
+    - Download files in a specific path from a job
+
+    Specify the path to a directory and download all its files and subdirectories.
+
+    Eg: --path models/checkpoint1
     """
     try:
         experiment = ExperimentClient().get(normalize_job_name(id, use_config=False))
@@ -139,15 +147,15 @@ def clone(id, directory):
         sys.exit("Cannot clone this version of the job. Try a different version.")
     module = ModuleClient().get(task_instance.module_id) if task_instance else None
 
-    # Download the full Code
-    if directory is None:
-        code_url = "{}/api/v1/resources/{}?content=true&download=true".format(floyd.floyd_host,
-                                                                              module.resource_id)
-    # Download a directory from Code
-    else:
+    if path:
+        # Download a directory from Code
         code_url = "{}/api/v1/download/artifacts/code/{}?is_dir=true&path={}".format(floyd.floyd_host,
                                                                                      experiment.id,
-                                                                                     directory)
+                                                                                     path)
+    else:
+        # Download the full Code
+        code_url = "{}/api/v1/resources/{}?content=true&download=true".format(floyd.floyd_host,
+                                                                              module.resource_id)
     ExperimentClient().download_tar(url=code_url,
                                     untar=True,
                                     delete_after_untar=True)

--- a/floyd/cli/experiment.py
+++ b/floyd/cli/experiment.py
@@ -119,7 +119,9 @@ def format_metrics(latest_metrics):
 
 @click.command()
 @click.argument('id', nargs=1)
-def clone(id):
+@click.option('--directory', '-d',
+              help='Download a directory from Job')
+def clone(id, directory):
     """
     Download files from a job.
 
@@ -136,8 +138,16 @@ def clone(id):
     if not task_instance:
         sys.exit("Cannot clone this version of the job. Try a different version.")
     module = ModuleClient().get(task_instance.module_id) if task_instance else None
-    code_url = "{}/api/v1/resources/{}?content=true&download=true".format(floyd.floyd_host,
-                                                                          module.resource_id)
+
+    # Download the full Code
+    if directory is None:
+        code_url = "{}/api/v1/resources/{}?content=true&download=true".format(floyd.floyd_host,
+                                                                              module.resource_id)
+    # Download a directory from Code
+    else:
+        code_url = "{}/api/v1/download/artifacts/code/{}?is_dir=true&path={}".format(floyd.floyd_host,
+                                                                                     experiment.id,
+                                                                                     directory)
     ExperimentClient().download_tar(url=code_url,
                                     untar=True,
                                     delete_after_untar=True)

--- a/floyd/cli/run.py
+++ b/floyd/cli/run.py
@@ -158,7 +158,7 @@ def show_new_job_info(expt_client, job_name, expt_info, mode, open_notebook=True
     job_url = '%s/%s' % (floyd.floyd_web_host, job_name)
     floyd_logger.info("URL to job: %s", job_url)
 
-    if show_data_info is not None:
+    if show_data_info:
         headers = ["DATANAME", "MOUNTING DIRECTORY"]
         floyd_logger.info('\n' + tabulate(show_data_info, headers=headers))
 


### PR DESCRIPTION
Now it's possible to download a directory from a Job or dataset with the `floyd [data] clone --directory <dir_name> ID`